### PR TITLE
Codecov: fix coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,5 @@ script:
   - export SPARKLIB=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.10.7-src.zip
   - export PYTHONPATH="${SPARKLIB}:${FINK_HOME}:${FINK_HOME}/python:$PYTHONPATH"
   - ./coverage_and_test.sh
+  - bash <(curl -s https://codecov.io/bash)
 
-after_success:
-  - codecov 

--- a/coverage_and_test.sh
+++ b/coverage_and_test.sh
@@ -18,9 +18,8 @@
 ## Must be launched as ./coverage_and_test.sh
 set -e
 
-# Then run the test suite
-cd python/fink_broker
-for i in *.py
+# Run the test suite on the modules
+for i in python/fink_broker/*.py
 do
     coverage run -a --source=. $i
 done

--- a/python/fink_broker/avroUtils.py
+++ b/python/fink_broker/avroUtils.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     """ Execute the test suite """
     # Add sample file to globals
     globs = globals()
-    globs["ztf_alert_sample"] = "../../schemas/template_schema_ZTF.avro"
+    globs["ztf_alert_sample"] = "schemas/template_schema_ZTF.avro"
 
     # Run the regular test suite
     regular_unit_tests(globs)


### PR DESCRIPTION
This PR brings fix for Codecov to operate properly. First one should not use:

```yml
script:
  - # do test

after_success
  - codecov
```

but rather:

```yml
script:
  - # do test
  - bash <(curl -s https://codecov.io/bash)
```

Second, all files must match the git/hg file structure. That means tests must be launched from the root of the repo (do not use `cd` to navigate and launch scripts).