### PR TITLE
Enable tests to run in a distributed environment

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-branch = true
+branch = false
 parallel = true
 data_file = ${PWD}/.coverage
 omit=

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = true
+parallel = true
+data_file = ${PWD}/.coverage
+omit=
+    $SPARK_HOME/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - tar -xf ./spark/spark-2.4.0-bin-hadoop2.7.tgz
   - export SPARK_HOME=`pwd`/spark-2.4.0-bin-hadoop2.7
   - echo "spark.yarn.jars=${SPARK_HOME}/jars/*.jar" > ${SPARK_HOME}/conf/spark-defaults.conf
+  - echo "spark.python.daemon.module coverage_daemon" > ${SPARK_HOME}/conf/spark-defaults.conf
 
   # Python deps
   - pip install --upgrade pip setuptools wheel
@@ -36,4 +37,3 @@ script:
   - export PYTHONPATH="${SPARKLIB}:${FINK_HOME}:${FINK_HOME}/python:$PYTHONPATH"
   - ./coverage_and_test.sh
   - bash <(curl -s https://codecov.io/bash)
-

--- a/coverage_and_test.sh
+++ b/coverage_and_test.sh
@@ -18,11 +18,19 @@
 ## Must be launched as ./coverage_and_test.sh
 set -e
 
+export PYTHONPATH="${SPARK_HOME}/python/test_coverage:$PYTHONPATH"
+export COVERAGE_PROCESS_START="$PWD/.coveragerc"
+
 # Run the test suite on the modules
 for i in python/fink_broker/*.py
 do
-    coverage run -a --source=. $i
+  coverage run --source=. $i
 done
+
+# Combine individual reports
+coverage combine
+
+unset COVERAGE_PROCESS_START
 
 ## Print and store the report if machine related to julien
 ## Otherwise the result is sent to codecov (see .travis.yml)


### PR DESCRIPTION
This PR enable tests to run in a distributed environment, that is driver & executors will be tested and covered. Example:

```python
import some_pandas_udf

df = # some dataframe

df.withColumn(
  "my-new-column", 
  some_pandas_udf(some_col) # executed only in executors!
)
```
In standard test mode, the function `some_pandas_udf` won't be covered as the driver does not execute it. In parallel execution, execution and coverage will be done on the executor side, and the coverage report combined afterwards with the rest of the coverage reports.