### PR TITLE
Upgrade travis dist to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 
+dist: xenial
+
 python:
   - "3.6"
+  - "3.7"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ addons:
   apt:
     packages:
       - axel
-      - oracle-java8-set-default
   sonarcloud:
     organization: "astrolabsoftware"
     token:
       secure: ${SONAR_KEY}
 
 before_install:
+  - source conf/java8_for_xenial.sh
   - export PATH=$HOME/.local/bin:$PATH
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
   apt:
     packages:
       - axel
-      - oracle-java8-installer
+      - oracle-java8-set-default
   sonarcloud:
     organization: "astrolabsoftware"
     token:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   apt:
     packages:
       - axel
+      - oracle-java8-installer
   sonarcloud:
     organization: "astrolabsoftware"
     token:

--- a/conf/java8_for_xenial.sh
+++ b/conf/java8_for_xenial.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2018 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Allow Java 8 on xenial
+
+# show current JAVA_HOME and java version
+echo "JAVA_HOME: $JAVA_HOME"
+
+# install Java 8
+sudo add-apt-repository -y ppa:openjdk-r/ppa
+sudo apt-get -qq update
+sudo apt-get install -y openjdk-8-jdk --no-install-recommends
+sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+
+# change JAVA_HOME to Java 8
+export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+
+echo "JAVA_HOME: $JAVA_HOME"


### PR DESCRIPTION
In order to test against python 3.7 in Travis, one should use the Xenial distribution. Unfortunately, Spark needs Java 8 which is not included in Xenial (Java 11 is the default). So this PR includes:
- Xenial distribution for Travis
- Test against 3.6 & 3.7
- Custom installer of Java 8 for Travis.

All tests successful.