### PR TITLE
Allow running services in simulation mode.

### DIFF
--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -58,10 +58,10 @@ KAFKA_IPPORT_SIM="localhost:29092"
 KAFKA_TOPIC_SIM="ztf-stream-sim"
 KAFKA_PORT_SIM=29092
 # Time between 2 alerts (second)
-TIME_INTERVAL=1
+TIME_INTERVAL=0.1
 
 # Maximum number of alerts to send
-POOLSIZE=5
+POOLSIZE=100
 
 ######################################
 # DEPENDENCIES

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -58,10 +58,10 @@ KAFKA_IPPORT_SIM="localhost:29092"
 KAFKA_TOPIC_SIM="ztf-stream-sim"
 KAFKA_PORT_SIM=29092
 # Time between 2 alerts (second)
-TIME_INTERVAL=1
+TIME_INTERVAL=0.1
 
 # Maximum number of alerts to send
-POOLSIZE=5
+POOLSIZE=100
 
 ######################################
 # DEPENDENCIES

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,83 @@
+# Welcome to Fink's documentation!
+
+## Overview
+
+Fink is a broker infrastructure using Apache Spark Streaming to receive and process alerts issued from telescopes all over the world. Fink core is based on the [Apache Spark](http://spark.apache.org/) framework, and more specifically its [streaming module](http://spark.apache.org/streaming/). Fink modules are written in Python, which is widely used in the astronomy community, has a large scientific ecosystem and easily connects with existing tools.
+
+## Rationale
+
+The design of Fink is driven by three pillars:
+
+* **Simplicity:** a broker should be simple enough to be used by a majority of scientists and maintained in real-time. This means the exposed API must be easily understood by anyone, and the code base should be as small as possible to allow easy maintenance and upgrade.
+* **Scalability:** broker's behaviour should be the same regardless the amount of incoming data. This implies the technology used for this is scalable.
+* **Flexibility:** the broker structure should allow for easy extension. As data will come, new features will be added, and the broker should be able to incorporate those smoothly. In addition, the broker should be able to connect to a large numbers of external tools and frameworks to maximize its scientific production without redeveloping tools.
+
+## Installation
+
+You need Python 3.6+, Apache Spark 2.4+, and docker-compose (latest) installed. Clone the repository:
+
+```bash
+git clone https://github.com/astrolabsoftware/fink-broker.git
+cd fink-broker
+```
+
+Then install the required python dependencies:
+
+```bash
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+Finally, define `FINK_HOME` and add the path to the fink modules in your `.bash_profile`:
+
+```bash
+# in ~/.bash_profile
+export FINK_HOME=/path/to/fink
+export PYTHONPATH=$FINK_HOME/python:$PYTHONPATH
+```
+
+Both the [webUI](user_guide/webui.md) and the [simulator](user_guide/simulator.md) rely on docker-compose.
+
+
+## Getting started
+
+In order to test the repo, we will simulate a stream of alert, and monitor it
+via the webUI. Start the webUI, and go to `http://localhost:5000`:
+```bash
+./fink start ui
+# Creating fink-broker_website_1 ... done
+# UI served at http://localhost:5000
+```
+
+Connect the monitoring service to the stream:
+```bash
+./fink start monitoring --simulator > live.log &
+```
+
+Send a small burst of alerts:
+```bash
+./fink start simulator
+```
+Now go to `http://localhost:5000/live.html` and see the alerts coming! The webUI
+should refresh automatically, but do it manually in case it does not work.
+Finally stop monitoring and shut down the UI simply using:
+```bash
+./fink stop monitoring
+./fink stop ui
+```
+
+To get help about `fink`, just type:
+
+```shell
+./fink
+Monitor Kafka stream received by Apache Spark
+Usage:
+    to start: ./fink start <service> [-c <conf>] [--simulator]
+    to stop : ./fink stop  <service> [-c <conf>]
+
+To get help:
+./fink -h or ./fink
+
+Available services are: ui, archive, monitoring, aggregation
+Typical configuration would be $FINK_HOME/conf/fink.conf
+```

--- a/fink
+++ b/fink
@@ -13,13 +13,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-message_service="Available services are: ui, monitoring, aggregation"
+message_service="Available services are: ui, archive, monitoring, aggregation"
 message_conf="Typical configuration would be $PWD/conf/fink.conf"
 message_help="""
 Monitor Kafka stream received by Apache Spark\n\n
 Usage:\n
-    \tto start: ./fink start <service> -c <conf>\n
-    \tto stop : ./fink stop  <service> -c <conf>\n\n
+    \tto start: ./fink start <service> [-c <conf>] [--simulator]\n
+    \tto stop : ./fink stop  <service> [-c <conf>]\n\n
 
 To get help: \n
 \t./fink -h or ./fink \n\n
@@ -65,6 +65,10 @@ while [ "$#" -gt 0 ]; do
         echo "$1 requires an argument" >&2
         exit 1
         ;;
+    --simulator)
+        SIM_ONLY=true
+        shift 1
+        ;;
     -*)
         echo "unknown option: $1" >&2
         exit 1
@@ -83,6 +87,11 @@ if [[ -f $conf ]]; then
 else
   echo "Reading default Fink conf from " ${FINK_HOME}/conf/fink.conf
   source ${FINK_HOME}/conf/fink.conf
+fi
+
+if [[ "$SIM_ONLY" = true ]] ; then
+  KAFKA_IPPORT=$KAFKA_IPPORT_SIM
+  KAFKA_TOPIC=$KAFKA_TOPIC_SIM
 fi
 
 # Stop services

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: Fink
+repo_url: https://github.com/astrolabsoftware/fink-broker
+
+nav:
+    - Home: index.md
+    - User Guide:
+      - Infrastructure: user_guide/infrastructure.md
+      - Configuration: user_guide/configuration.md
+      - Deploying a service: user_guide/deploying-your-docs.md
+      - Simulating streams: user_guide/simulator.md
+      - Testing Fink: user_guide/testing-the-broker.md
+      - Adding a new service: user_guide/writing-your-docs.md
+      - webUI: user_guide/webui.md
+    - About:
+      - Release Notes: release-notes.md
+      - Contributing: contributing.md
+      - License: license.md
+
+# theme: readthedocs
+
+copyright: Copyright &copy; 2018-19 <a href="https://astrolabsoftware.github.io/">AstroLab Software</a>.


### PR DESCRIPTION
This PR allows services to run in simulation mode, that is to connect to a local Kafka cluster for testing purposes. The syntax is simply:

```bash
./fink start <service> --simulator
```

And then send alerts via the simulator:
```bash
./fink start simulator
```