### PR TITLE
Fix wrong links for internal pages in the doc and update doc

### DIFF
--- a/docs/user_guide/available-services.md
+++ b/docs/user_guide/available-services.md
@@ -1,0 +1,33 @@
+# Available Fink services
+
+Fink provides built-in services operating at different levels:
+
+- Operating from the stream or from the database
+- Real time or post-processing of alerts.
+- Urgent decision to take (observation plan).
+
+Given the crazy rate of alerts, it seems insane to live monitor each alert individually, and on short timescales it makes more sense to focus on some physically motivated statistics on the stream, target potential outliers, and highlight problems. On longer timescales, we want of course also to be able to access, inspect, and process each alert received by Fink. Each service is a Spark job on the database, but the archive service that operates directly on the stream.
+
+Each Spark job is either batch or streaming, or both (multi-modal analytics). All services are linked to the [webUI](webui.md), and you can easily follow live and interactively the outputs. For example, if you want to start classifying the alerts from the database, just launch:
+
+```bash
+./fink start classify > classify.log &
+```
+
+and go to `http://localhost:5000/classification.html`
+
+Note you can easily define your own service in Fink, and connect it to the alert database. See [Adding a new service](adding-new-service.md) for more information.
+
+## Archive (from stream)
+
+## Monitoring (from stream)
+
+## Early classification (from database)
+
+Perform the cross-match between incoming alert position and external catalogs to start classifying the object type. Short timescale.
+
+## Outlier detection (WIP)
+Short timescale.
+
+## Light-curve inspection (WIP)
+Long timescale.

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -55,7 +55,7 @@ org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.0,\
 org.apache.spark:spark-avro_2.11:2.4.0
 ```
 
-As described in [Infrastructure](/user_guide/infrastructure/), data streams are processed as a series of small batch jobs. You can specify the time interval between two triggers (second), i.e. the timing of streaming data processing. If `0`, the query will be executed in micro-batch mode, where micro-batches will be generated as soon as the previous micro-batch has completed processing. Note that this timing is also used for updating data for the webUI.
+As described in [Infrastructure](infrastructure.md), data streams are processed as a series of small batch jobs. You can specify the time interval between two triggers (second), i.e. the timing of streaming data processing. If `0`, the query will be executed in micro-batch mode, where micro-batches will be generated as soon as the previous micro-batch has completed processing. Note that this timing is also used for updating data for the webUI.
 ```
 FINK_TRIGGER_UPDATE=2
 ```

--- a/docs/user_guide/infrastructure.md
+++ b/docs/user_guide/infrastructure.md
@@ -35,7 +35,7 @@ Concerning the first 3 points, benchmarks and resources sizing are under work. F
 
 Just make sure you attached the `archive` service to disks with large enough space! To define the location, see `conf/fink.conf`, or follow steps in [Configuration](configuration.md).
 
-There is a monitoring service attached to the database construction. Unfortunately at the time of writing, there is no built-in listeners in pyspark to monitor structured streaming queries. So we had to develop custom tools, and redirect information in the Fink [webUI](/user_guide/webui/). This is automatically done when you start the `archive` service. Just launch the Fink UI and go to `http://localhost:5000/live.html` to see the incoming rate and consumption (archiving) rate:
+There is a monitoring service attached to the database construction. Unfortunately at the time of writing, there is no built-in listeners in pyspark to monitor structured streaming queries. So we had to develop custom tools, and redirect information in the Fink [webUI](webui.md). This is automatically done when you start the `archive` service. Just launch the Fink UI and go to `http://localhost:5000/live.html` to see the incoming rate and consumption (archiving) rate:
 
 ```bash
 ./fink start ui
@@ -63,7 +63,7 @@ We provide some built-in services in Fink, operating at different levels:
 - Outlier detection: WIP. Short timescale.
 - Light-curve inspection: WIP. Long timescale.
 
-Each service is Spark job on the database - either batch or streaming, or both (multi-modal analytics). All services are linked to the [webUI](/user_guide/webui/), and you can easily follow live and interactively the outputs. For example, if you want to start classifying the alerts, just launch:
+Each service is Spark job on the database - either batch or streaming, or both (multi-modal analytics). All services are linked to the [webUI](webui.md), and you can easily follow live and interactively the outputs. For example, if you want to start classifying the alerts, just launch:
 
 ```bash
 ./fink start classify > classify.log &
@@ -72,7 +72,7 @@ Each service is Spark job on the database - either batch or streaming, or both (
 and go to `http://localhost:5000/classification.html`
 
 
-Note you can easily define your own service in Fink, and connect it to the alert database. See [Adding a new service](/user_guide/adding-new-service/) for more information.
+Note you can easily define your own service in Fink, and connect it to the alert database. See [Adding a new service](adding-new-service.md) for more information.
 
 ### AstroLabNet
 
@@ -98,4 +98,4 @@ This will set up the simulator and send a stream of alerts. Then test a service 
 ./fink start <service> --simulator
 ```
 
-See [Simulator](/user_guide/simulator/) for more information.
+See [Simulator](simulator.md) for more information.

--- a/docs/user_guide/infrastructure.md
+++ b/docs/user_guide/infrastructure.md
@@ -55,22 +55,19 @@ Note this will stop all Fink services running.
 
 ![Screenshot](../img/monitoring.png)
 
-Fink must operate at different timescales. But all timescales must be treated differently, and by different services. Given the crazy rate of alerts, it seems insane to live monitor each alert individually. So on short timescale, it makes more sense to focus on some physically motivated statistics on the stream, target potential outliers, and highlight problems. On longer timescales, we want of course also to be able to access, inspect, and process each alert received by Fink.
+Fink provides built-in services, described in [Available Services](available-services.md). They operate at different timescales, and with various objectives:
 
-We provide some built-in services in Fink, operating at different levels:
+- Operating from the stream or from the database
+- Real time or post-processing of alerts.
+- Urgent decision to take (observation plan).
 
-- Early classification: Perform the cross-match between incoming alert position and external catalogs to start classifying the object type. Short timescale.
-- Outlier detection: WIP. Short timescale.
-- Light-curve inspection: WIP. Long timescale.
-
-Each service is Spark job on the database - either batch or streaming, or both (multi-modal analytics). All services are linked to the [webUI](webui.md), and you can easily follow live and interactively the outputs. For example, if you want to start classifying the alerts, just launch:
+Each service is Spark job on the database - either batch or streaming, or both (multi-modal analytics). All services are linked to the [webUI](webui.md), and you can easily follow live and interactively the outputs. For example, if you want to start classifying the alerts from the database, just launch:
 
 ```bash
 ./fink start classify > classify.log &
 ```
 
 and go to `http://localhost:5000/classification.html`
-
 
 Note you can easily define your own service in Fink, and connect it to the alert database. See [Adding a new service](adding-new-service.md) for more information.
 


### PR DESCRIPTION
mkdocs does not behave the same on `serve` mode or from readthedocs. The later needs the relative path to internal files:

```bash
docs/
  index.md
  folder/
    other_page.md
```

So linking `index.md` from `other_page.md` should be done using:
```markdown
<!-- Will work only for serve -->
[index][/index/]

<!-- Will work both ways -->
[index][../index.md]
```