### PR TITLE
KAFKA_IPPORT_SIM vs KAFKA_PORT_SIM

### DIFF
--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -16,7 +16,7 @@
 # Infrastructure
 # Kafka producer stream location
 KAFKA_IPPORT="134.158.74.95:24499"
-KAFKA_TOPIC="ztf-stream-os"
+KAFKA_TOPIC="ztf-stream-os-toto"
 
 # Apache Spark mode
 SPARK_MASTER="local[*]"
@@ -61,9 +61,9 @@ FINK_UI_PORT=5000
 # Simulator
 # Simulate a fake stream, and access it locally
 # Kafka producer stream location:
-KAFKA_IPPORT_SIM="localhost:29092"
-KAFKA_TOPIC_SIM="ztf-stream-sim"
 KAFKA_PORT_SIM=29092
+KAFKA_IPPORT_SIM="localhost:${KAFKA_PORT_SIM}"
+KAFKA_TOPIC_SIM="ztf-stream-sim"
 # Time between 2 alerts (second)
 TIME_INTERVAL=0.1
 

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -16,7 +16,7 @@
 # Infrastructure
 # Kafka producer stream location
 KAFKA_IPPORT="134.158.74.95:24499"
-KAFKA_TOPIC="ztf-stream-os-toto"
+KAFKA_TOPIC="ztf-stream-os"
 
 # Apache Spark mode
 SPARK_MASTER="local[*]"

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -61,9 +61,9 @@ FINK_UI_PORT=5000
 # Simulator
 # Simulate a fake stream, and access it locally
 # Kafka producer stream location:
-KAFKA_IPPORT_SIM="localhost:29092"
-KAFKA_TOPIC_SIM="ztf-stream-sim"
 KAFKA_PORT_SIM=29092
+KAFKA_IPPORT_SIM="localhost:${KAFKA_PORT_SIM}"
+KAFKA_TOPIC_SIM="ztf-stream-sim"
 # Time between 2 alerts (second)
 TIME_INTERVAL=0.1
 


### PR DESCRIPTION
In the configuration, we now re-use `KAFKA_PORT_SIM` for setting `KAFKA_IPPORT_SIM` instead of having the port definition twice.