### PR TITLE
Add helper for each service

### DIFF
--- a/bin/archive.py
+++ b/bin/archive.py
@@ -41,13 +41,13 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         'servers', type=str,
-        help='Hostname or IP and port of Kafka broker producing stream.')
+        help='Hostname or IP and port of Kafka broker producing stream. [KAFKA_IPPORT]')
     parser.add_argument(
         'topic', type=str,
-        help='Name of Kafka topic stream to read from.')
+        help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
     parser.add_argument(
         'outputpath', type=str,
-        help='Directory on disk for saving live data. See conf/fink.conf.')
+        help='Directory on disk for saving live data. [FINK_ALERT_PATH]')
     parser.add_argument(
         'checkpointpath', type=str,
         help="""
@@ -57,13 +57,14 @@ def main():
         in an HDFS-compatible fault-tolerant file system.
         See conf/fink.conf & https://spark.apache.org/docs/latest/
         structured-streaming-programming-guide.html#starting-streaming-queries
+        [FINK_ALERT_CHECKPOINT]
         """)
     parser.add_argument(
         'finkwebpath', type=str,
-        help='Folder to store UI data for display. See conf/fink.conf')
+        help='Folder to store UI data for display. [FINK_UI_PATH]')
     parser.add_argument(
         'tinterval', type=int,
-        help='Time interval between two monitoring. In seconds.')
+        help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
     args = parser.parse_args()
 
     # Grab the running Spark Session,

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -34,16 +34,16 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         'servers', type=str,
-        help='Hostname or IP and port of Kafka broker producing stream.')
+        help='Hostname or IP and port of Kafka broker producing stream. [KAFKA_IPPORT]')
     parser.add_argument(
         'topic', type=str,
-        help='Name of Kafka topic stream to read from.')
+        help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
     parser.add_argument(
         'finkwebpath', type=str,
-        help='Folder to store UI data for display. See conf/fink.conf')
+        help='Folder to store UI data for display. [FINK_UI_PATH]')
     parser.add_argument(
         'tinterval', type=int,
-        help='Time interval between two monitoring. In seconds.')
+        help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
     args = parser.parse_args()
 
     # Grab the running Spark Session,

--- a/bin/monitor_fromstream.py
+++ b/bin/monitor_fromstream.py
@@ -27,13 +27,13 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         'servers', type=str,
-        help='Hostname or IP and port of Kafka broker producing stream.')
+        help='Hostname or IP and port of Kafka broker producing stream. [KAFKA_IPPORT]')
     parser.add_argument(
         'topic', type=str,
-        help='Name of Kafka topic stream to read from.')
+        help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
     parser.add_argument(
         'finkwebpath', type=str,
-        help='Folder to store UI data for display. See conf/fink.conf')
+        help='Folder to store UI data for display. [FINK_UI_PATH]')
     args = parser.parse_args()
 
     # Grab the running Spark Session,

--- a/bin/simulate_stream.py
+++ b/bin/simulate_stream.py
@@ -26,16 +26,23 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         'broker', type=str,
-        help='Hostname or IP and port of Kafka broker.')
+        help='Hostname or IP and port of Kafka broker. [KAFKA_IPPORT_SIM]')
     parser.add_argument(
         'topic', type=str,
-        help='Name of Kafka topic stream to push to.')
+        help='Name of Kafka topic stream to push to. [KAFKA_TOPIC_SIM]')
+    parser.add_argument(
+        'datapath', type=str,
+        help='Folder containing alerts to be published. [FINK_DATA_SIM]')
     parser.add_argument(
         'tinterval', type=float,
-        help='Interval between two alerts (second)')
+        help='Interval between two alerts (second). [TIME_INTERVAL]')
     parser.add_argument(
         'poolsize', type=int,
-        help='Maximum number of alerts to send')
+        help="""
+Maximum number of alerts to send. If the poolsize is
+bigger than the number of alerts in `datapath`, then we replicate
+the alerts. [POOLSIZE]
+""")
     args = parser.parse_args()
 
     # Configure producer connection to Kafka broker

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,13 +86,17 @@ To get help about `fink`, just type:
 ```shell
 ./fink
 Monitor Kafka stream received by Apache Spark
-Usage:
-    to start: ./fink start <service> [-c <conf>] [--simulator]
-    to stop : ./fink stop  <service> [-c <conf>]
 
-To get help:
-./fink -h or ./fink
+ Usage:
+ 	to start: ./fink start <service> [-h] [-c <conf>] [--simulator]
+ 	to stop : ./fink stop <service> [-h] [-c <conf>]
 
-Available services are: dashboard, archive, monitoring, classify
-Typical configuration would be $FINK_HOME/conf/fink.conf
+ To get this help:
+ 	./fink
+
+ To get help for a service:
+ 	./fink start <service> -h
+
+ Available services are: dashboard, archive, monitoring, classify
+ Typical configuration would be ${FINK_HOME}/conf/fink.conf
 ```

--- a/docs/user_guide/available-services.md
+++ b/docs/user_guide/available-services.md
@@ -22,7 +22,13 @@ Each Spark job is either batch or streaming, or both (multi-modal analytics). Al
 ./fink start <service_name> > output.log &
 ```
 
-For convenience, we redirect the console output to a log file, and escape. You can also use tools like `nohup`. To stop services, simply use:
+For convenience, we redirect the console output to a log file, and escape. You can also use tools like `nohup`. You easily get help on a service using:
+
+```bash
+./fink start <service_name> -h
+```
+
+This will also tells you which configuration parameters are used. To stop services, simply use:
 
 ```bash
 ./fink stop services

--- a/docs/user_guide/howto.md
+++ b/docs/user_guide/howto.md
@@ -67,7 +67,7 @@ Monitor Kafka stream received by Apache Spark
  	to stop : ./fink stop <service> [-h] [-c <conf>]
 
  To get this help:
- 	./fink -h or ./fink
+ 	./fink
 
  To get help for a service:
  	./fink start <service> -h

--- a/docs/user_guide/howto.md
+++ b/docs/user_guide/howto.md
@@ -102,6 +102,31 @@ Just redirect the output and escape:
 ./fink start <service> > service.log &
 ```
 
+### How do I get help on a service?
+
+You easily get help on a service using:
+
+```bash
+./fink start <service_name> -h
+```
+
+This will also tells you which configuration parameters are used, e.g.
+
+```bash
+./fink start monitoring -h
+usage: monitor_fromstream.py [-h] servers topic finkwebpath
+
+Monitor Kafka stream received by Spark
+
+positional arguments:
+  servers      Hostname or IP and port of Kafka broker producing stream.
+               [KAFKA_IPPORT]
+  topic        Name of Kafka topic stream to read from. [KAFKA_TOPIC]
+  finkwebpath  Folder to store UI data for display. [FINK_UI_PATH]
+
+optional arguments:
+  -h, --help   show this help message and exit
+```
 
 ### Spark's verbosity is overwhelming my logs!
 

--- a/docs/user_guide/howto.md
+++ b/docs/user_guide/howto.md
@@ -61,15 +61,19 @@ If you want to know which services are available:
 ```bash
 ./fink
 Monitor Kafka stream received by Apache Spark
-Usage:
-    to start: ./fink start <service> [-c <conf>] [--simulator]
-    to stop : ./fink stop  <service> [-c <conf>]
 
-To get help:
-./fink -h or ./fink
+ Usage:
+ 	to start: ./fink start <service> [-h] [-c <conf>] [--simulator]
+ 	to stop : ./fink stop <service> [-h] [-c <conf>]
 
-Available services are: dashboard, archive, monitoring, classify
-Typical configuration would be $FINK_HOME/conf/fink.conf
+ To get this help:
+ 	./fink -h or ./fink
+
+ To get help for a service:
+ 	./fink start <service> -h
+
+ Available services are: dashboard, archive, monitoring, classify
+ Typical configuration would be ${FINK_HOME}/conf/fink.conf
 ```
 
 ### How do I stop a service?

--- a/fink
+++ b/fink
@@ -48,8 +48,8 @@ while [ "$#" -gt 0 ]; do
         shift 2
         ;;
     -h)
-        echo -e ${message_help}
-        exit 1
+        HELP_ON_SERVICE="-h"
+        shift 1
         ;;
     -c)
         if [[ $2 == "" || $2 == "-s" ]]; then
@@ -127,21 +127,22 @@ elif [[ $service == "simulator" ]]; then
   KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -f docker-compose-kafka.yml up -d
 
   python bin/simulate_stream.py \
-    ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${TIME_INTERVAL} ${POOLSIZE}
+    ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM}\
+    ${TIME_INTERVAL} ${POOLSIZE} ${HELP_ON_SERVICE}
 elif [[ $service == "monitoring" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
       --packages ${FINK_PACKAGES} \
       ${EXTRA_SPARK_CONFIG} \
       bin/monitor_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
-      ${FINK_UI_PATH}
+      ${FINK_UI_PATH} ${HELP_ON_SERVICE}
 elif [[ $service == "classify" ]]; then
   # Aggregate the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
       --packages ${FINK_PACKAGES} \
       ${EXTRA_SPARK_CONFIG} \
       bin/classify_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
-      ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE}
+      ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${HELP_ON_SERVICE}
 elif [[ $service == "archive" ]]; then
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
@@ -149,7 +150,7 @@ elif [[ $service == "archive" ]]; then
       ${EXTRA_SPARK_CONFIG} \
       bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
       ${FINK_ALERT_PATH} ${FINK_ALERT_CHECKPOINT} \
-      ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE}
+      ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${HELP_ON_SERVICE}
 else
   # In case you give an unknown service
   echo "unknown service: $service" >&2

--- a/fink
+++ b/fink
@@ -20,11 +20,14 @@ message_conf="Typical configuration would be $PWD/conf/fink.conf"
 message_help="""
 Monitor Kafka stream received by Apache Spark\n\n
 Usage:\n
-    \tto start: ./fink start <service> [-c <conf>] [--simulator]\n
-    \tto stop : ./fink stop  <service> [-c <conf>]\n\n
+    \tto start: ./fink start <service> [-h] [-c <conf>] [--simulator]\n
+    \tto stop : ./fink stop  <service> [-h] [-c <conf>]\n\n
 
-To get help: \n
+To get this help: \n
 \t./fink -h or ./fink \n\n
+
+To get help for a service: \n
+\t./fink start <service> -h\n\n
 
 $message_service\n
 $message_conf

--- a/fink
+++ b/fink
@@ -24,7 +24,7 @@ Usage:\n
     \tto stop : ./fink stop  <service> [-h] [-c <conf>]\n\n
 
 To get this help: \n
-\t./fink -h or ./fink \n\n
+\t./fink \n\n
 
 To get help for a service: \n
 \t./fink start <service> -h\n\n

--- a/fink
+++ b/fink
@@ -126,6 +126,7 @@ elif [[ $service == "simulator" ]]; then
   # Launch the simulator - kafka & zookeeper
   KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -f docker-compose-kafka.yml up -d
 
+  FINK_DATA_SIM=${FINK_HOME}/datasim
   python bin/simulate_stream.py \
     ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM}\
     ${TIME_INTERVAL} ${POOLSIZE} ${HELP_ON_SERVICE}


### PR DESCRIPTION
This PR adds a helper for each service, e.g.:

```bash
./fink start monitoring -h
usage: monitor_fromstream.py [-h] servers topic finkwebpath

Monitor Kafka stream received by Spark

positional arguments:
  servers      Hostname or IP and port of Kafka broker producing stream.
               [KAFKA_IPPORT]
  topic        Name of Kafka topic stream to read from. [KAFKA_TOPIC]
  finkwebpath  Folder to store UI data for display. [FINK_UI_PATH]

optional arguments:
  -h, --help   show this help message and exit
```

The help tells you which configuration parameters must be set.