### PR TITLE
Generate alerts from disk

### DIFF
--- a/bin/archive.py
+++ b/bin/archive.py
@@ -46,6 +46,9 @@ def main():
         'topic', type=str,
         help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
     parser.add_argument(
+        'schema', type=str,
+        help='Schema to decode the alert. Should be avro file. [FINK_ALERT_SCHEMA]')
+    parser.add_argument(
         'outputpath', type=str,
         help='Directory on disk for saving live data. [FINK_ALERT_PATH]')
     parser.add_argument(
@@ -95,11 +98,10 @@ def main():
         .load()
 
     # Get Schema of alerts
-    alert_schema = readschemafromavrofile(
-        "schemas/template_schema_ZTF.avro")
+    alert_schema = readschemafromavrofile(args.schema)
     df_schema = spark.read\
         .format("avro")\
-        .load("schemas/template_schema_ZTF.avro")\
+        .load(args.schema)\
         .schema
     alert_schema_json = json.dumps(alert_schema)
 

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -39,6 +39,9 @@ def main():
         'topic', type=str,
         help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
     parser.add_argument(
+        'schema', type=str,
+        help='Schema to decode the alert. Should be avro file. [FINK_ALERT_SCHEMA]')
+    parser.add_argument(
         'finkwebpath', type=str,
         help='Folder to store UI data for display. [FINK_UI_PATH]')
     parser.add_argument(
@@ -74,11 +77,10 @@ def main():
         .load()
 
     # Get Schema of alerts
-    alert_schema = readschemafromavrofile(
-        "schemas/template_schema_ZTF.avro")
+    alert_schema = readschemafromavrofile(args.schema)
     df_schema = spark.read\
         .format("avro")\
-        .load("schemas/template_schema_ZTF.avro")\
+        .load(args.schema)\
         .schema
     alert_schema_json = json.dumps(alert_schema)
 

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -41,7 +41,7 @@ FINK_TRIGGER_UPDATE=2
 
 # Alert schema
 # Full path to schema to decode the alerts
-FINK_SCHEMA=${FINK_HOME}/schemas/template_schema_ZTF.avro
+FINK_ALERT_SCHEMA=${FINK_HOME}/schemas/template_schema_ZTF.avro
 
 # Path on disk to save live data. Paths must exist.
 # They can be in local FS (files:///path/) or

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -41,7 +41,7 @@ FINK_TRIGGER_UPDATE=2
 
 # Alert schema
 # Full path to schema to decode the alerts
-FINK_SCHEMA=${FINK_HOME}/schemas/template_schema_ZTF.avro
+FINK_ALERT_SCHEMA=${FINK_HOME}/schemas/template_schema_ZTF.avro
 
 # Path on disk to save live data. Paths must exist.
 # They can be in local FS (files:///path/) or

--- a/datasim/download_ztf_alert_data.sh
+++ b/datasim/download_ztf_alert_data.sh
@@ -13,8 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e
+
 # Download subset of ZTF public data - 22 MB (zipped)
 wget https://ztf.uw.edu/alerts/public/ztf_public_20181129.tar.gz
 
 # Untar the alert data - 55 MB
 tar -zxvf ztf_public_20181129.tar.gz
+rm ztf_public_20181129.tar.gz

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -60,6 +60,12 @@ As described in [Infrastructure](infrastructure.md), data streams are processed 
 FINK_TRIGGER_UPDATE=2
 ```
 
+You also need to provide the schema to decode the alert. To make it simple,
+Fink takes one alert as the reference:
+```bash
+FINK_ALERT_SCHEMA=${FINK_HOME}/schemas/template_schema_ZTF.avro
+```
+
 Finally, you need to provide location on disk to save the incoming alerts.
 They can be in local FS (`files:///path/`) or in distributed FS (e.g. `hdfs:///path/`). Be careful though to have enough disk space!
 ```
@@ -89,7 +95,13 @@ KAFKA_TOPIC_SIM="ztf-stream-sim"
 KAFKA_PORT_SIM=29092
 ```
 
-The time in between two alerts are sent:
+The simulator generates the stream from alerts stored on disk. You need to
+provide the folder containing such alerts:
+```
+FINK_DATA_SIM=${FINK_HOME}/datasim
+```
+
+The time in between two alerts:
 ```
 # Time between 2 alerts (second)
 TIME_INTERVAL=0.1

--- a/docs/user_guide/simulator.md
+++ b/docs/user_guide/simulator.md
@@ -1,12 +1,29 @@
 # Fink simulator
 
-For testing purposes, Fink includes a service to simulate incoming streams. The service is provided through docker-compose, and include Kafka and Zookeeper clusters. By default alerts will be published on the port 29092 (localhost), but you can change it in the [configuration](configuration.md). To start the simulator and send alerts, just execute:
+For testing purposes, Fink includes a service to simulate incoming streams. The service is provided through docker-compose, and include Kafka and Zookeeper clusters.
+The simulator generates the stream from alerts stored on disk. We provide a script to download a subset of ZTF alerts that will be used to generate streams:
+
+```bash
+cd ${FINK_HOME}/datasim
+./download_ztf_alert_data.sh
+# ...download 499 alerts
+```
+
+You can change this folder with your data, but make sure you correctly set the schema and the data path in the configuration:
+
+```bash
+# in configuration file
+FINK_ALERT_SCHEMA=...
+FINK_DATA_SIM=...
+```
+
+By default alerts will be published on the port 29092 (localhost), but you can change it in the [configuration](configuration.md). To start the simulator and send alerts, just execute:
 
 ```bash
 ./fink start simulator
 ```
 
-With the default configuration, it will publish 100 alerts during 10 seconds in a topic called `ztf-stream-sim`. You can change all of it in the configuration file. All services can be run on the simulated stream by just specifying the argument `--simulator`:
+With the default configuration, it will publish 100 alerts during 10 seconds in a topic called `ztf-stream-sim`. You can change all of it in the configuration file. Note if you want to publish more alerts than what is available on disk, alerts will be replicated on-the-fly to match the desired number. All services can be run on the simulated stream by just specifying the argument `--simulator`:
 
 ```bash
 ./fink start <service> --simulator

--- a/fink
+++ b/fink
@@ -144,14 +144,14 @@ elif [[ $service == "classify" ]]; then
   spark-submit --master ${SPARK_MASTER} \
       --packages ${FINK_PACKAGES} \
       ${EXTRA_SPARK_CONFIG} \
-      bin/classify_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
+      bin/classify_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
       ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${HELP_ON_SERVICE}
 elif [[ $service == "archive" ]]; then
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
       --packages ${FINK_PACKAGES} \
       ${EXTRA_SPARK_CONFIG} \
-      bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
+      bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
       ${FINK_ALERT_PATH} ${FINK_ALERT_CHECKPOINT} \
       ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${HELP_ON_SERVICE}
 else


### PR DESCRIPTION
This PR brings change concerning the simulator. Now simulated streams are generated from a folder of alerts on disk. For convenience, a script to download a subset of ZTF public alert data is provided (committed previously).

In addition, the definition of the schema has been put inside the configuration (instead of being hardcoded in the service).