### PR TITLE
Move fink into the binary folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - export FINK_HOME="/home/travis/build/astrolabsoftware/fink-broker"
   # Install Java 8 for Xenial
   - source conf/java8_for_xenial.sh
-  - export PATH=$HOME/.local/bin:$PATH
+  - export PATH=$HOME/.local/bin:${FINK_HOME}/bin:$PATH
   # Download data used for the test suite
   - cd datasim; ./download_ztf_alert_data.sh; cd ..
 
@@ -39,7 +39,7 @@ install:
 
 script:
   # Execute tests and report coverage
-  - ./fink start simulator -c conf/fink.conf.travis
+  - fink start simulator -c ${FINK_HOME}/conf/fink.conf.travis
   - ./coverage_and_test.sh
   - bash <(curl -s https://codecov.io/bash)
 

--- a/bin/fink
+++ b/bin/fink
@@ -103,9 +103,9 @@ fi
 if [[ $MODE == "stop" ]]; then
   if [[ $service == "dashboard" ]]; then
     # PID=$(lsof -t -i :${FINKUIPORT})
-    FINK_UI_PORT=${FINK_UI_PORT} docker-compose -f docker-compose-ui.yml down
+    FINK_HOME=${FINK_HOME} FINK_UI_PORT=${FINK_UI_PORT} docker-compose -f ${FINK_HOME}/docker-compose-ui.yml down
   elif [[ $service == "simulator" ]]; then
-    KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -f docker-compose-kafka.yml down
+    KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -f ${FINK_HOME}/docker-compose-kafka.yml down
   else
     SIGNAL=${SIGNAL:-TERM}
     PIDS=$(ps ax | grep -i 'fink' | grep -v grep | awk '{print $1}')
@@ -123,13 +123,13 @@ fi
 # Start services
 if [[ $service == "dashboard" ]]; then
   # Launch the UI
-  FINK_UI_PORT=${FINK_UI_PORT} docker-compose -f docker-compose-ui.yml up -d
+  FINK_HOME=${FINK_HOME} FINK_UI_PORT=${FINK_UI_PORT} docker-compose -f ${FINK_HOME}/docker-compose-ui.yml up -d
   echo "Dashboard served at http://localhost:${FINK_UI_PORT}"
 elif [[ $service == "simulator" ]]; then
   # Launch the simulator - kafka & zookeeper
-  KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -f docker-compose-kafka.yml up -d
+  KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -f ${FINK_HOME}/docker-compose-kafka.yml up -d
 
-  python bin/simulate_stream.py \
+  python ${FINK_HOME}/bin/simulate_stream.py \
     ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM}\
     ${TIME_INTERVAL} ${POOLSIZE} ${HELP_ON_SERVICE}
 elif [[ $service == "monitoring" ]]; then
@@ -137,21 +137,22 @@ elif [[ $service == "monitoring" ]]; then
   spark-submit --master ${SPARK_MASTER} \
       --packages ${FINK_PACKAGES} \
       ${EXTRA_SPARK_CONFIG} \
-      bin/monitor_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
+      ${FINK_HOME}/bin/monitor_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
       ${FINK_UI_PATH} ${HELP_ON_SERVICE}
 elif [[ $service == "classify" ]]; then
   # Aggregate the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
       --packages ${FINK_PACKAGES} \
       ${EXTRA_SPARK_CONFIG} \
-      bin/classify_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
+      ${FINK_HOME}/bin/classify_fromstream.py ${KAFKA_IPPORT} \
+      ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
       ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${HELP_ON_SERVICE}
 elif [[ $service == "archive" ]]; then
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
       --packages ${FINK_PACKAGES} \
       ${EXTRA_SPARK_CONFIG} \
-      bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
+      ${FINK_HOME}/bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
       ${FINK_ALERT_PATH} ${FINK_ALERT_CHECKPOINT} \
       ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${HELP_ON_SERVICE}
 else

--- a/docker-compose-ui.yml
+++ b/docker-compose-ui.yml
@@ -20,6 +20,6 @@ services:
   website:
     image: httpd:2.4-alpine
     volumes:
-      - ./web:/usr/local/apache2/htdocs/
+      - ${FINK_HOME}/web:/usr/local/apache2/htdocs/
     ports:
       - ${FINK_UI_PORT}:80


### PR DESCRIPTION
In order to prepare for the first release (see #21), `fink` has been moved into the bin folder. This means all paths have been made absolute (using `${FINK_HOME}`).