### PR TITLE
Add integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - echo "spark.python.daemon.module coverage_daemon" > ${SPARK_HOME}/conf/spark-defaults.conf
   - export SPARKLIB=${SPARK_HOME}/python:${SPARK_HOME}/python/lib/py4j-0.10.7-src.zip
   - export PYTHONPATH="${SPARKLIB}:${FINK_HOME}:${FINK_HOME}/python:$PYTHONPATH"
+  - export PATH="${SPARK_HOME}/bin:${SPARK_HOME}/sbin:${PATH}"
 
   # Python deps
   - pip install --upgrade pip setuptools wheel

--- a/bin/fink
+++ b/bin/fink
@@ -44,8 +44,8 @@ while [ "$#" -gt 0 ]; do
     "start"|"stop")
         MODE="$1"
         if [[ $2 == "" || $2 == "-c" ]]; then
-            echo "$1 requires an argument. ${message_service}" >&2
-            exit 1
+          echo "$1 requires an argument. ${message_service}" >&2
+          exit 1
         fi
         service="$2"
         shift 2
@@ -56,8 +56,8 @@ while [ "$#" -gt 0 ]; do
         ;;
     -c)
         if [[ $2 == "" || $2 == "-s" ]]; then
-            echo "$1 requires an argument. ${message_conf}" >&2
-            exit 1
+          echo "$1 requires an argument. ${message_conf}" >&2
+          exit 1
         fi
         conf="$2"
         shift 2
@@ -73,6 +73,10 @@ while [ "$#" -gt 0 ]; do
     --simulator)
         SIM_ONLY=true
         shift 1
+        ;;
+    --exit_after)
+        EXIT_AFTER="$2"
+        shift 2
         ;;
     -*)
         echo "unknown option: $1" >&2
@@ -139,6 +143,7 @@ elif [[ $service == "simulator" ]]; then
     KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -p kafkanet -f ${FINK_HOME}/docker/docker-compose-kafka.yml up -d
   else
     echo "docker-compose not found"
+    exit
   fi
   python ${FINK_HOME}/bin/simulate_stream.py \
     ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM}\
@@ -146,28 +151,29 @@ elif [[ $service == "simulator" ]]; then
 elif [[ $service == "monitoring" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-      --packages ${FINK_PACKAGES} \
-      ${EXTRA_SPARK_CONFIG} \
-      ${FINK_HOME}/bin/monitor_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
-      ${FINK_UI_PATH} ${HELP_ON_SERVICE}
+    --packages ${FINK_PACKAGES} \
+    ${EXTRA_SPARK_CONFIG} \
+    ${FINK_HOME}/bin/monitor_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
+    ${FINK_UI_PATH} ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "classify" ]]; then
   # Aggregate the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-      --packages ${FINK_PACKAGES} \
-      ${EXTRA_SPARK_CONFIG} \
-      ${FINK_HOME}/bin/classify_fromstream.py ${KAFKA_IPPORT} \
-      ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
-      ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${HELP_ON_SERVICE}
+    --packages ${FINK_PACKAGES} \
+    ${EXTRA_SPARK_CONFIG} \
+    ${FINK_HOME}/bin/classify_fromstream.py ${KAFKA_IPPORT} \
+    ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
+    ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "archive" ]]; then
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-      --packages ${FINK_PACKAGES} \
-      ${EXTRA_SPARK_CONFIG} \
-      ${FINK_HOME}/bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
-      ${FINK_ALERT_PATH} ${FINK_ALERT_CHECKPOINT} \
-      ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${HELP_ON_SERVICE}
+    --packages ${FINK_PACKAGES} \
+    ${EXTRA_SPARK_CONFIG} \
+    ${FINK_HOME}/bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
+    ${FINK_ALERT_PATH} ${FINK_ALERT_CHECKPOINT} \
+    ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${EXIT_AFTER} ${HELP_ON_SERVICE}
 else
   # In case you give an unknown service
   echo "unknown service: $service" >&2
   echo $message_service
+  exit 1
 fi

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -17,6 +17,17 @@
 ## Must be launched as fink_test
 set -e
 
+# Grab the command line arguments
+NO_INTEGRATION=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --without-integration)
+        NO_INTEGRATION=true
+        shift 1
+        ;;
+  esac
+done
+
 # Add coverage_daemon to the pythonpath. See python/fink_broker/tester.py
 export PYTHONPATH="${SPARK_HOME}/python/test_coverage:$PYTHONPATH"
 export COVERAGE_PROCESS_START="${FINK_HOME}/.coveragerc"
@@ -28,6 +39,33 @@ do
     --source=${FINK_HOME} \
     --rcfile ${FINK_HOME}/.coveragerc $i
 done
+
+# Integration tests
+if [[ "$NO_INTEGRATION" = false ]] ; then
+  source $FINK_HOME/conf/fink.conf.travis
+
+  # Launch the simulator - kafka & zookeeper
+  is_docker=`which docker-compose`
+  if [[ -f $is_docker ]]; then
+    KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -p kafkanet -f ${FINK_HOME}/docker/docker-compose-kafka.yml up -d
+  else
+    echo "docker-compose not found"
+    echo "integration tests cannot be performed"
+    exit
+  fi
+
+  # # Test the simulator
+  coverage run --source=${FINK_HOME} \
+      --rcfile ${FINK_HOME}/.coveragerc \
+      ${FINK_HOME}/bin/simulate_stream.py \
+        ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM} \
+        ${TIME_INTERVAL} ${POOLSIZE}
+
+  fink start monitoring --exit_after 5 --simulator
+  fink start archive --exit_after 30 --simulator
+  fink start classify --exit_after 30 --simulator
+  fink start dashboard
+fi
 
 # Combine individual reports in one
 coverage combine

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -16,6 +16,15 @@
 ## Script to launch the python test suite and measure the coverage.
 ## Must be launched as fink_test
 set -e
+message_help="""
+Run the test suite of Fink\n\n
+Usage:\n
+    \tfink_test [--without-integration] [-h]\n\n
+
+By default, both unit tests and integration tests will be run.\n
+You can disable the integration tests by specifying --without-integration.\n
+Use -h to display this help.
+"""
 
 # Grab the command line arguments
 NO_INTEGRATION=false
@@ -24,6 +33,10 @@ while [ "$#" -gt 0 ]; do
     --without-integration)
         NO_INTEGRATION=true
         shift 1
+        ;;
+    -h)
+        echo -e $message_help
+        exit
         ;;
   esac
 done

--- a/bin/monitor_fromstream.py
+++ b/bin/monitor_fromstream.py
@@ -34,6 +34,11 @@ def main():
     parser.add_argument(
         'finkwebpath', type=str,
         help='Folder to store UI data for display. [FINK_UI_PATH]')
+    parser.add_argument(
+        'exit_after', type=int, default=None,
+        help=""" Stop the service after `exit_after` seconds.
+        This primarily for use on Travis, to stop service after some time.
+        Use that with `fink start service --exit_after <time>`. Default is None. """)
     args = parser.parse_args()
 
     # Grab the running Spark Session,
@@ -78,7 +83,12 @@ def main():
         args.finkwebpath)
 
     # Keep the Streaming running until something or someone ends it!
-    countquery.awaitTermination()
+    if args.exit_after is not None:
+        time.sleep(args.exit_after)
+        countquery.stop()
+        print("Exiting the monitoring service normally...")
+    else:
+        countquery.awaitTermination()
 
 if __name__ == "__main__":
     main()

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -76,4 +76,4 @@ FINK_DATA_SIM=${FINK_HOME}/datasim
 TIME_INTERVAL=0.1
 
 # Total number of alerts to send
-POOLSIZE=100
+POOLSIZE=10

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,10 +60,10 @@ Both the [dashboard](user_guide/dashboard.md) and the [simulator](user_guide/sim
 First make sure the test suite is running fine. Just execute:
 
 ```bash
-fink_test
+fink_test [--without-integration] [-h]
 ```
 
-You should see plenty of Spark logs (and yet we have shut most of them!), but no failures hopefully! Success is silent, and the coverage is printed on screen at the end. Then let's test some functionalities of Fink by simulating a stream of alert, and monitoring it
+You should see plenty of Spark logs (and yet we have shut most of them!), but no failures hopefully! Success is silent, and the coverage is printed on screen at the end. You can disable integration tests by specifying the argument `--without-integration`. Then let's test some functionalities of Fink by simulating a stream of alert, and monitoring it
 via the dashboard. Start the dashboard, and go to `http://localhost:5000`:
 ```bash
 fink start dashboard

--- a/docs/user_guide/testing-fink.md
+++ b/docs/user_guide/testing-fink.md
@@ -16,10 +16,18 @@ The test suite must take into account that Fink is using distributing computing 
 We provide a script to execute the test suite and report coverage of Fink code base:
 
 ```bash
-fink_test
+fink_test [--without-integration] [-h]
+Run the test suite of Fink
+
+ Usage:
+ 	fink_test [--without-integration] [-h]
+
+ By default, both unit tests and integration tests will be run.
+ You can disable the integration tests by specifying --without-integration.
+ Use -h to display this help.
 ```
 
-You should see plenty of verbose logs from Apache Spark at screen (and yet we have shut most of them!), `DeprecationWarning` that we need to handle quickly, and eventually failures will be printed out (success is silent) like:
+Both unit tests and integration tests will be run. You can disable the integration tests by specifying `--without-integration`. Then you should see plenty of verbose logs from Apache Spark at screen (and yet we have shut most of them!), `DeprecationWarning` that we need to handle at some point, and eventually failures will be printed out (success is silent) like:
 
 ```bash
 **********************************************************************
@@ -37,16 +45,20 @@ If no failures, hooray, the code passes the test suite! Which obviously does not
 ```bash
 Name                                   Stmts   Miss  Cover
 ----------------------------------------------------------
+bin/archive.py                            45      3    93%
+bin/classify_fromstream.py                47      3    94%
+bin/monitor_fromstream.py                 27      1    96%
+bin/simulate_stream.py                    41      3    93%
 python/__init__.py                         0      0   100%
 python/fink_broker/__init__.py             0      0   100%
-python/fink_broker/alertProducer.py       37      3    92%
-python/fink_broker/avroUtils.py           22      0   100%
+python/fink_broker/alertProducer.py       39      3    92%
+python/fink_broker/avroUtils.py           24      0   100%
 python/fink_broker/classification.py      51      3    94%
-python/fink_broker/monitoring.py          37     11    70%
-python/fink_broker/sparkUtils.py          19      0   100%
+python/fink_broker/monitoring.py          37      2    95%
+python/fink_broker/sparkUtils.py          22      0   100%
 python/fink_broker/tester.py              27      2    93%
 ----------------------------------------------------------
-TOTAL                                    193     19    90%
+TOTAL                                    360     20    94%
 ```
 
 ## Template for adding unit tests


### PR DESCRIPTION
Following #34, this PR adds the suite of integration tests. This is automatically run with `fink_test`:

```bash
fink_test [--without-integration] [-h]
Run the test suite of Fink

 Usage:
 	fink_test [--without-integration] [-h]

 By default, both unit tests and integration tests will be run.
 You can disable the integration tests by specifying --without-integration.
 Use -h to display this help.
```

By integration tests, we mean testing the service from end-to-end. In order to not be stuck forever with a running service, each service will run for sometime, and exit gracefully.