### PR TITLE
Use named arg instead of positional for `--exit_after`

### DIFF
--- a/bin/archive.py
+++ b/bin/archive.py
@@ -70,7 +70,7 @@ def main():
         'tinterval', type=int,
         help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
     parser.add_argument(
-        'exit_after', type=int, default=None,
+        '-exit_after', type=int, default=None,
         help=""" Stop the service after `exit_after` seconds.
         This primarily for use on Travis, to stop service after some time.
         Use that with `fink start service --exit_after <time>`. Default is None. """)

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -49,7 +49,7 @@ def main():
         'tinterval', type=int,
         help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
     parser.add_argument(
-        'exit_after', type=int, default=None,
+        '-exit_after', type=int, default=None,
         help=""" Stop the service after `exit_after` seconds.
         This primarily for use on Travis, to stop service after some time.
         Use that with `fink start service --exit_after <time>`. Default is None. """)

--- a/bin/fink
+++ b/bin/fink
@@ -75,7 +75,7 @@ while [ "$#" -gt 0 ]; do
         shift 1
         ;;
     --exit_after)
-        EXIT_AFTER="$2"
+        EXIT_AFTER="-exit_after $2"
         shift 2
         ;;
     -*)

--- a/bin/monitor_fromstream.py
+++ b/bin/monitor_fromstream.py
@@ -35,7 +35,7 @@ def main():
         'finkwebpath', type=str,
         help='Folder to store UI data for display. [FINK_UI_PATH]')
     parser.add_argument(
-        'exit_after', type=int, default=None,
+        '-exit_after', type=int, default=None,
         help=""" Stop the service after `exit_after` seconds.
         This primarily for use on Travis, to stop service after some time.
         Use that with `fink start service --exit_after <time>`. Default is None. """)


### PR DESCRIPTION
This PR fixes a bug when the newly `--exit_after` was left empty (positional args do not take default value).