### PR TITLE
Cluster integration

### DIFF
--- a/bin/archive.py
+++ b/bin/archive.py
@@ -107,7 +107,7 @@ def main():
     alert_schema = readschemafromavrofile(args.schema)
     df_schema = spark.read\
         .format("avro")\
-        .load("files://" + args.schema)\
+        .load("file://" + args.schema)\
         .schema
     alert_schema_json = json.dumps(alert_schema)
 

--- a/bin/archive.py
+++ b/bin/archive.py
@@ -70,7 +70,7 @@ def main():
         'tinterval', type=int,
         help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
     parser.add_argument(
-        'exit_after', type=int, default=None,
+        '-exit_after', type=int, default=None,
         help=""" Stop the service after `exit_after` seconds.
         This primarily for use on Travis, to stop service after some time.
         Use that with `fink start service --exit_after <time>`. Default is None. """)

--- a/bin/archive.py
+++ b/bin/archive.py
@@ -107,7 +107,7 @@ def main():
     alert_schema = readschemafromavrofile(args.schema)
     df_schema = spark.read\
         .format("avro")\
-        .load(args.schema)\
+        .load("files://" + args.schema)\
         .schema
     alert_schema_json = json.dumps(alert_schema)
 

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -86,7 +86,7 @@ def main():
     alert_schema = readschemafromavrofile(args.schema)
     df_schema = spark.read\
         .format("avro")\
-        .load("files://" + args.schema)\
+        .load("file://" + args.schema)\
         .schema
     alert_schema_json = json.dumps(alert_schema)
 

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -86,7 +86,7 @@ def main():
     alert_schema = readschemafromavrofile(args.schema)
     df_schema = spark.read\
         .format("avro")\
-        .load(args.schema)\
+        .load("files://" + args.schema)\
         .schema
     alert_schema_json = json.dumps(alert_schema)
 

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -49,7 +49,7 @@ def main():
         'tinterval', type=int,
         help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
     parser.add_argument(
-        'exit_after', type=int, default=None,
+        '-exit_after', type=int, default=None,
         help=""" Stop the service after `exit_after` seconds.
         This primarily for use on Travis, to stop service after some time.
         Use that with `fink start service --exit_after <time>`. Default is None. """)

--- a/bin/fink
+++ b/bin/fink
@@ -127,7 +127,7 @@ fi
 # Start services
 if [[ $service == "dashboard" ]]; then
   # Launch the UI
-  is_docker=`which docker-compose`
+  is_docker=`command -v docker-compose`
   if [[ -f $is_docker ]]; then
     FINK_HOME=${FINK_HOME} FINK_UI_PORT=${FINK_UI_PORT} docker-compose -p dashboardnet -f ${FINK_HOME}/docker/docker-compose-ui.yml up -d
   else
@@ -138,7 +138,7 @@ if [[ $service == "dashboard" ]]; then
   echo "Dashboard served at http://localhost:${FINK_UI_PORT}"
 elif [[ $service == "simulator" ]]; then
   # Launch the simulator - kafka & zookeeper
-  is_docker=`which docker-compose`
+  is_docker=`command -v docker-compose`
   if [[ -f $is_docker ]]; then
     KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -p kafkanet -f ${FINK_HOME}/docker/docker-compose-kafka.yml up -d
   else

--- a/bin/fink
+++ b/bin/fink
@@ -75,7 +75,7 @@ while [ "$#" -gt 0 ]; do
         shift 1
         ;;
     --exit_after)
-        EXIT_AFTER="$2"
+        EXIT_AFTER="-exit_after $2"
         shift 2
         ;;
     -*)

--- a/bin/fink
+++ b/bin/fink
@@ -125,20 +125,23 @@ if [[ $MODE == "stop" ]]; then
 fi
 
 # Start services
+mkdir -p ${FINK_HOME}/web/data
 if [[ $service == "dashboard" ]]; then
   # Launch the UI
-  is_docker=`command -v docker-compose`
+  export is_docker=`command -v docker-compose`
   if [[ -f $is_docker ]]; then
     FINK_HOME=${FINK_HOME} FINK_UI_PORT=${FINK_UI_PORT} docker-compose -p dashboardnet -f ${FINK_HOME}/docker/docker-compose-ui.yml up -d
   else
     echo "docker-compose not found, using python -m http.server"
     echo "This is a workaround and work only from the repo root."
+    cd ${FINK_HOME}/web
     python -m http.server ${FINK_UI_PORT}
+    cd -
   fi
   echo "Dashboard served at http://localhost:${FINK_UI_PORT}"
 elif [[ $service == "simulator" ]]; then
   # Launch the simulator - kafka & zookeeper
-  is_docker=`command -v docker-compose`
+  export is_docker=`command -v docker-compose`
   if [[ -f $is_docker ]]; then
     KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -p kafkanet -f ${FINK_HOME}/docker/docker-compose-kafka.yml up -d
   else

--- a/bin/monitor_fromstream.py
+++ b/bin/monitor_fromstream.py
@@ -35,7 +35,7 @@ def main():
         'finkwebpath', type=str,
         help='Folder to store UI data for display. [FINK_UI_PATH]')
     parser.add_argument(
-        'exit_after', type=int, default=None,
+        '-exit_after', type=int, default=None,
         help=""" Stop the service after `exit_after` seconds.
         This primarily for use on Travis, to stop service after some time.
         Use that with `fink start service --exit_after <time>`. Default is None. """)

--- a/conf/fink.conf.cluster
+++ b/conf/fink.conf.cluster
@@ -1,0 +1,79 @@
+# Copyright 2018 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######################################
+# Infrastructure
+# Kafka producer stream location
+KAFKA_IPPORT="134.158.74.95:24499"
+KAFKA_TOPIC="ztf-stream-os"
+
+# Apache Spark mode
+SPARK_MASTER="spark://134.158.75.222:7077"
+
+# Should be Spark options actually (to allow cluster resources!)
+EXTRA_SPARK_CONFIG="--driver-memory 4g --executor-memory 30g --executor-cores 17 --total-executor-cores 51"
+
+# These are the Maven Coordinates of dependencies for Fink
+# Change the version according to your Spark version.
+FINK_PACKAGES=\
+org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.0,\
+org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.0,\
+org.apache.spark:spark-avro_2.11:2.4.0
+
+# Time interval between 2 trigger updates (second)
+# i.e. the timing of streaming data processing.
+# If 0, the query will be executed in micro-batch mode,
+# where micro-batches will be generated as soon as the previous
+# micro-batch has completed processing.
+# Note that this timing is also used for updating the dashboard.
+FINK_TRIGGER_UPDATE=2
+
+# Alert schema
+# Full path to schema to decode the alerts
+FINK_ALERT_SCHEMA="${FINK_HOME}/schemas/template_schema_ZTF.avro"
+
+# Path on disk to save live data. Paths must exist.
+# They can be in local FS (files:///path/) or
+# in distributed FS (e.g. hdfs:///path/).
+# Be careful though to have enough disk space!
+FINK_ALERT_PATH="hdfs://134.158.75.222:8020//user/julien.peloton/archive/alerts_store"
+
+FINK_ALERT_CHECKPOINT="hdfs://134.158.75.222:8020//user/julien.peloton/archive/alerts_checkpoint"
+
+######################################
+# Dashboard
+# Where the web data will be posted and retrieved by the UI.
+# For small files, you can keep this location.
+# If you plan on having large files, change to a better suited location.
+FINK_UI_PATH=${FINK_HOME}/web/data
+
+# The UI will listen on this port
+FINK_UI_PORT=24500
+
+######################################
+# Simulator
+# Simulate a fake stream, and access it locally
+# Kafka producer stream location:
+KAFKA_PORT_SIM=29092
+KAFKA_IPPORT_SIM="localhost:${KAFKA_PORT_SIM}"
+KAFKA_TOPIC_SIM="ztf-stream-sim"
+
+# Where the data for sims is
+FINK_DATA_SIM=${FINK_HOME}/datasim
+
+# Time between 2 alerts (second)
+TIME_INTERVAL=0.1
+
+# Total number of alerts to send
+POOLSIZE=100


### PR DESCRIPTION
This PR introduces few change for use on a cluster. Especially:
- typical configuration file
- include FS naming (`file://` vs `hdfs://`)
- Switch from docker-compose to python -m http.server for the dashboard if docker-compose is not installed.