### PR TITLE
Add bin/ folder into sonar

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.projectVersion=1.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # This property is optional if sonar.modules is set.
-sonar.sources=python/
+sonar.sources=python/,bin/
 sonar.exclusions=python/fink_broker/htmlcov
 
 # Path to coverage file (need xml)


### PR DESCRIPTION
This PR allows Sonar to monitor the `bin` folder.