### PR TITLE
Services code and test suite refactoring

### DIFF
--- a/bin/archive.py
+++ b/bin/archive.py
@@ -35,6 +35,7 @@ import time
 from fink_broker.avroUtils import readschemafromavrofile
 from fink_broker.sparkUtils import quiet_logs, from_avro
 from fink_broker.sparkUtils import init_sparksession, connect_with_kafka
+from fink_broker.sparkUtils import get_schemas_from_avro
 
 from fink_broker.monitoring import monitor_progress_webui
 
@@ -80,7 +81,7 @@ def main():
     args = parser.parse_args()
 
     # Initialise Spark session
-    spark = init_sparksession(
+    init_sparksession(
         name="archivingStream", shuffle_partitions=2, log_level="ERROR")
 
     # Create a streaming dataframe pointing to a Kafka stream
@@ -89,12 +90,7 @@ def main():
         startingoffsets=args.startingoffsets, failondataloss=False)
 
     # Get Schema of alerts
-    alert_schema = readschemafromavrofile(args.schema)
-    df_schema = spark.read\
-        .format("avro")\
-        .load("file://" + args.schema)\
-        .schema
-    alert_schema_json = json.dumps(alert_schema)
+    alert_schema, alert_schema_json = get_schemas_from_avro(args.schema)
 
     # Decode the Avro data, and keep only (timestamp, data)
     df_decoded = df.select(

--- a/bin/archive.py
+++ b/bin/archive.py
@@ -32,6 +32,8 @@ import argparse
 import json
 import time
 
+from fink_broker.parser import getargs
+
 from fink_broker.avroUtils import readschemafromavrofile
 from fink_broker.sparkUtils import quiet_logs, from_avro
 from fink_broker.sparkUtils import init_sparksession, connect_with_kafka
@@ -41,44 +43,7 @@ from fink_broker.monitoring import monitor_progress_webui
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        'servers', type=str,
-        help='Hostname or IP and port of Kafka broker producing stream. [KAFKA_IPPORT]')
-    parser.add_argument(
-        'topic', type=str,
-        help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
-    parser.add_argument(
-        'schema', type=str,
-        help='Schema to decode the alert. Should be avro file. [FINK_ALERT_SCHEMA]')
-    parser.add_argument(
-        'startingoffsets', type=str,
-        help='From which offset you want to start pulling data. [KAFKA_STARTING_OFFSET]')
-    parser.add_argument(
-        'outputpath', type=str,
-        help='Directory on disk for saving live data. [FINK_ALERT_PATH]')
-    parser.add_argument(
-        'checkpointpath', type=str,
-        help="""
-        For some output sinks where the end-to-end fault-tolerance
-        can be guaranteed, specify the location where the system will
-        write all the checkpoint information. This should be a directory
-        in an HDFS-compatible fault-tolerant file system.
-        See conf/fink.conf & https://spark.apache.org/docs/latest/
-        structured-streaming-programming-guide.html#starting-streaming-queries
-        [FINK_ALERT_CHECKPOINT]
-        """)
-    parser.add_argument(
-        'finkwebpath', type=str,
-        help='Folder to store UI data for display. [FINK_UI_PATH]')
-    parser.add_argument(
-        'tinterval', type=int,
-        help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
-    parser.add_argument(
-        '-exit_after', type=int, default=None,
-        help=""" Stop the service after `exit_after` seconds.
-        This primarily for use on Travis, to stop service after some time.
-        Use that with `fink start service --exit_after <time>`. Default is None. """)
-    args = parser.parse_args()
+    args = getargs(parser)
 
     # Initialise Spark session
     init_sparksession(

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -26,10 +26,10 @@ import time
 from fink_broker.avroUtils import readschemafromavrofile
 from fink_broker.sparkUtils import quiet_logs, from_avro
 from fink_broker.sparkUtils import write_to_csv
+from fink_broker.sparkUtils import init_sparksession, connect_with_kafka
 
 from fink_broker.classification import cross_match_alerts_per_batch
 from fink_broker.monitoring import monitor_progress_webui
-
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -43,6 +43,9 @@ def main():
         'schema', type=str,
         help='Schema to decode the alert. Should be avro file. [FINK_ALERT_SCHEMA]')
     parser.add_argument(
+        'startingoffsets', type=str,
+        help='From which offset you want to start pulling data. [KAFKA_STARTING_OFFSET]')
+    parser.add_argument(
         'finkwebpath', type=str,
         help='Folder to store UI data for display. [FINK_UI_PATH]')
     parser.add_argument(
@@ -55,32 +58,14 @@ def main():
         Use that with `fink start service --exit_after <time>`. Default is None. """)
     args = parser.parse_args()
 
-    # Grab the running Spark Session,
-    # otherwise create it.
-    spark = SparkSession \
-        .builder \
-        .appName("classifyStream") \
-        .getOrCreate()
+    # Initialise Spark session
+    spark = init_sparksession(
+        name="archivingStream", shuffle_partitions=2, log_level="ERROR")
 
-    # Set logs to be quieter
-    # Put WARN or INFO for debugging, but you will have to dive into
-    # a sea of millions irrelevant messages for what you typically need...
-    quiet_logs(spark.sparkContext, log_level="ERROR")
-    spark.conf.set("spark.streaming.kafka.consumer.cache.enabled", "false")
-
-    # Keep the size of shuffles small
-    spark.conf.set("spark.sql.shuffle.partitions", "2")
-
-    # Create a DF from the incoming stream from Kafka
-    # Note that <kafka.bootstrap.servers> and <subscribe>
-    # must correspond to arguments of the LSST alert system.
-    df = spark \
-        .readStream \
-        .format("kafka") \
-        .option("kafka.bootstrap.servers", args.servers) \
-        .option("subscribe", args.topic) \
-        .option("startingOffsets", "latest") \
-        .load()
+    # Create a streaming dataframe pointing to a Kafka stream
+    df = connect_with_kafka(
+        servers=args.servers, topic=args.topic,
+        startingoffsets=args.startingoffsets, failondataloss=False)
 
     # Get Schema of alerts
     alert_schema = readschemafromavrofile(args.schema)

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -23,6 +23,8 @@ import argparse
 import json
 import time
 
+from fink_broker.parser import getargs
+
 from fink_broker.avroUtils import readschemafromavrofile
 from fink_broker.sparkUtils import quiet_logs, from_avro
 from fink_broker.sparkUtils import write_to_csv
@@ -34,34 +36,11 @@ from fink_broker.monitoring import monitor_progress_webui
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        'servers', type=str,
-        help='Hostname or IP and port of Kafka broker producing stream. [KAFKA_IPPORT]')
-    parser.add_argument(
-        'topic', type=str,
-        help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
-    parser.add_argument(
-        'schema', type=str,
-        help='Schema to decode the alert. Should be avro file. [FINK_ALERT_SCHEMA]')
-    parser.add_argument(
-        'startingoffsets', type=str,
-        help='From which offset you want to start pulling data. [KAFKA_STARTING_OFFSET]')
-    parser.add_argument(
-        'finkwebpath', type=str,
-        help='Folder to store UI data for display. [FINK_UI_PATH]')
-    parser.add_argument(
-        'tinterval', type=int,
-        help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
-    parser.add_argument(
-        '-exit_after', type=int, default=None,
-        help=""" Stop the service after `exit_after` seconds.
-        This primarily for use on Travis, to stop service after some time.
-        Use that with `fink start service --exit_after <time>`. Default is None. """)
-    args = parser.parse_args()
+    args = getargs(parser)
 
     # Initialise Spark session
     init_sparksession(
-        name="archivingStream", shuffle_partitions=2, log_level="ERROR")
+        name="classifyStream", shuffle_partitions=2, log_level="ERROR")
 
     # Create a streaming dataframe pointing to a Kafka stream
     df = connect_with_kafka(

--- a/bin/fink
+++ b/bin/fink
@@ -157,14 +157,14 @@ elif [[ $service == "monitoring" ]]; then
     --packages ${FINK_PACKAGES} \
     ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/monitor_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
-    ${FINK_UI_PATH} ${EXIT_AFTER} ${HELP_ON_SERVICE}
+    ${KAFKA_STARTING_OFFSET} ${FINK_UI_PATH} ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "classify" ]]; then
   # Aggregate the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/classify_fromstream.py ${KAFKA_IPPORT} \
-    ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
+    ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} ${KAFKA_STARTING_OFFSET} \
     ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "archive" ]]; then
   # Store the stream of alerts
@@ -172,7 +172,7 @@ elif [[ $service == "archive" ]]; then
     --packages ${FINK_PACKAGES} \
     ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
-    ${FINK_ALERT_PATH} ${FINK_ALERT_CHECKPOINT} \
+    ${KAFKA_STARTING_OFFSET} ${FINK_ALERT_PATH} ${FINK_ALERT_CHECKPOINT} \
     ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${EXIT_AFTER} ${HELP_ON_SERVICE}
 else
   # In case you give an unknown service

--- a/bin/fink
+++ b/bin/fink
@@ -149,31 +149,35 @@ elif [[ $service == "simulator" ]]; then
     exit
   fi
   python ${FINK_HOME}/bin/simulate_stream.py \
-    ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM}\
-    ${TIME_INTERVAL} ${POOLSIZE} ${HELP_ON_SERVICE}
+    -servers ${KAFKA_IPPORT_SIM} -topic ${KAFKA_TOPIC_SIM} -datapath ${FINK_DATA_SIM}\
+    -tinterval_kafka ${TIME_INTERVAL} -poolsize ${POOLSIZE} ${HELP_ON_SERVICE}
 elif [[ $service == "monitoring" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     ${EXTRA_SPARK_CONFIG} \
-    ${FINK_HOME}/bin/monitor_fromstream.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} \
-    ${KAFKA_STARTING_OFFSET} ${FINK_UI_PATH} ${EXIT_AFTER} ${HELP_ON_SERVICE}
+    ${FINK_HOME}/bin/monitor_fromstream.py -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
+    -startingoffsets ${KAFKA_STARTING_OFFSET} -finkwebpath ${FINK_UI_PATH} \
+    ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "classify" ]]; then
   # Aggregate the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     ${EXTRA_SPARK_CONFIG} \
-    ${FINK_HOME}/bin/classify_fromstream.py ${KAFKA_IPPORT} \
-    ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} ${KAFKA_STARTING_OFFSET} \
-    ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${EXIT_AFTER} ${HELP_ON_SERVICE}
+    ${FINK_HOME}/bin/classify_fromstream.py -servers ${KAFKA_IPPORT} \
+    -topic ${KAFKA_TOPIC} -schema ${FINK_ALERT_SCHEMA} -startingoffsets ${KAFKA_STARTING_OFFSET} \
+    -finkwebpath ${FINK_UI_PATH} -tinterval ${FINK_TRIGGER_UPDATE} \
+    ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "archive" ]]; then
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     ${EXTRA_SPARK_CONFIG} \
-    ${FINK_HOME}/bin/archive.py ${KAFKA_IPPORT} ${KAFKA_TOPIC} ${FINK_ALERT_SCHEMA} \
-    ${KAFKA_STARTING_OFFSET} ${FINK_ALERT_PATH} ${FINK_ALERT_CHECKPOINT} \
-    ${FINK_UI_PATH} ${FINK_TRIGGER_UPDATE} ${EXIT_AFTER} ${HELP_ON_SERVICE}
+    ${FINK_HOME}/bin/archive.py -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
+    -schema ${FINK_ALERT_SCHEMA} -startingoffsets ${KAFKA_STARTING_OFFSET} \
+    -outputpath ${FINK_ALERT_PATH} -checkpointpath ${FINK_ALERT_CHECKPOINT} \
+    -finkwebpath ${FINK_UI_PATH} -tinterval ${FINK_TRIGGER_UPDATE} \
+    ${EXIT_AFTER} ${HELP_ON_SERVICE}
 else
   # In case you give an unknown service
   echo "unknown service: $service" >&2

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -66,8 +66,8 @@ fi
 coverage run --source=${FINK_HOME} \
     --rcfile ${FINK_HOME}/.coveragerc \
     ${FINK_HOME}/bin/simulate_stream.py \
-      ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM} \
-      ${TIME_INTERVAL} ${POOLSIZE}
+      -servers ${KAFKA_IPPORT_SIM} -topic ${KAFKA_TOPIC_SIM} -datapath ${FINK_DATA_SIM} \
+      -tinterval_kafka ${TIME_INTERVAL} -poolsize ${POOLSIZE}
 
 # Run the test suite on the modules
 for i in ${FINK_HOME}/python/fink_broker/*.py

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -41,9 +41,33 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+# Source configuration file for tests
+source $FINK_HOME/conf/fink.conf.travis
+export FINK_PACKAGES=$FINK_PACKAGES
+export KAFKA_IPPORT_SIM=$KAFKA_IPPORT_SIM
+export KAFKA_TOPIC_SIM=$KAFKA_TOPIC_SIM
+echo "Reading test configuration from $FINK_HOME/conf/fink.conf.travis"
+
 # Add coverage_daemon to the pythonpath. See python/fink_broker/tester.py
 export PYTHONPATH="${SPARK_HOME}/python/test_coverage:$PYTHONPATH"
 export COVERAGE_PROCESS_START="${FINK_HOME}/.coveragerc"
+
+# Launch the simulator - kafka & zookeeper
+is_docker=`which docker-compose`
+if [[ -f $is_docker ]]; then
+  KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -p kafkanet -f ${FINK_HOME}/docker/docker-compose-kafka.yml up -d
+else
+  echo "docker-compose not found"
+  echo "integration tests cannot be performed"
+  exit
+fi
+
+# Launch a stream from the simulator to be used by tests
+coverage run --source=${FINK_HOME} \
+    --rcfile ${FINK_HOME}/.coveragerc \
+    ${FINK_HOME}/bin/simulate_stream.py \
+      ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM} \
+      ${TIME_INTERVAL} ${POOLSIZE}
 
 # Run the test suite on the modules
 for i in ${FINK_HOME}/python/fink_broker/*.py
@@ -55,25 +79,6 @@ done
 
 # Integration tests
 if [[ "$NO_INTEGRATION" = false ]] ; then
-  source $FINK_HOME/conf/fink.conf.travis
-
-  # Launch the simulator - kafka & zookeeper
-  is_docker=`which docker-compose`
-  if [[ -f $is_docker ]]; then
-    KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -p kafkanet -f ${FINK_HOME}/docker/docker-compose-kafka.yml up -d
-  else
-    echo "docker-compose not found"
-    echo "integration tests cannot be performed"
-    exit
-  fi
-
-  # # Test the simulator
-  coverage run --source=${FINK_HOME} \
-      --rcfile ${FINK_HOME}/.coveragerc \
-      ${FINK_HOME}/bin/simulate_stream.py \
-        ${KAFKA_IPPORT_SIM} ${KAFKA_TOPIC_SIM} ${FINK_DATA_SIM} \
-        ${TIME_INTERVAL} ${POOLSIZE}
-
   fink start monitoring --exit_after 5 --simulator
   fink start archive --exit_after 30 --simulator
   fink start classify --exit_after 30 --simulator
@@ -84,6 +89,9 @@ fi
 coverage combine
 
 unset COVERAGE_PROCESS_START
+unset FINK_PACKAGES
+unset KAFKA_IPPORT_SIM
+unset KAFKA_TOPIC_SIM
 
 coverage report
 coverage html

--- a/bin/monitor_fromstream.py
+++ b/bin/monitor_fromstream.py
@@ -20,6 +20,8 @@ from pyspark.sql import SparkSession
 import argparse
 import time
 
+from fink_broker.parser import getargs
+
 from fink_broker.sparkUtils import quiet_logs
 from fink_broker.sparkUtils import init_sparksession, connect_with_kafka
 
@@ -27,28 +29,11 @@ from fink_broker.monitoring import monitor_progress_webui
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        'servers', type=str,
-        help='Hostname or IP and port of Kafka broker producing stream. [KAFKA_IPPORT]')
-    parser.add_argument(
-        'topic', type=str,
-        help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
-    parser.add_argument(
-        'startingoffsets', type=str,
-        help='From which offset you want to start pulling data. [KAFKA_STARTING_OFFSET]')
-    parser.add_argument(
-        'finkwebpath', type=str,
-        help='Folder to store UI data for display. [FINK_UI_PATH]')
-    parser.add_argument(
-        '-exit_after', type=int, default=None,
-        help=""" Stop the service after `exit_after` seconds.
-        This primarily for use on Travis, to stop service after some time.
-        Use that with `fink start service --exit_after <time>`. Default is None. """)
-    args = parser.parse_args()
+    args = getargs(parser)
 
     # Initialise Spark session
     init_sparksession(
-        name="archivingStream", shuffle_partitions=2, log_level="ERROR")
+        name="monitoringStream", shuffle_partitions=2, log_level="ERROR")
 
     # Create a streaming dataframe pointing to a Kafka stream
     df = connect_with_kafka(

--- a/bin/monitor_fromstream.py
+++ b/bin/monitor_fromstream.py
@@ -21,6 +21,8 @@ import argparse
 import time
 
 from fink_broker.sparkUtils import quiet_logs
+from fink_broker.sparkUtils import init_sparksession, connect_with_kafka
+
 from fink_broker.monitoring import monitor_progress_webui
 
 def main():
@@ -32,6 +34,9 @@ def main():
         'topic', type=str,
         help='Name of Kafka topic stream to read from. [KAFKA_TOPIC]')
     parser.add_argument(
+        'startingoffsets', type=str,
+        help='From which offset you want to start pulling data. [KAFKA_STARTING_OFFSET]')
+    parser.add_argument(
         'finkwebpath', type=str,
         help='Folder to store UI data for display. [FINK_UI_PATH]')
     parser.add_argument(
@@ -41,29 +46,14 @@ def main():
         Use that with `fink start service --exit_after <time>`. Default is None. """)
     args = parser.parse_args()
 
-    # Grab the running Spark Session,
-    # otherwise create it.
-    spark = SparkSession \
-        .builder \
-        .appName("monitorStream") \
-        .getOrCreate()
+    # Initialise Spark session
+    spark = init_sparksession(
+        name="archivingStream", shuffle_partitions=2, log_level="ERROR")
 
-    # Set logs to be quieter
-    # Put WARN or INFO for debugging, but you will have to dive into
-    # a sea of millions irrelevant messages for what you typically need...
-    quiet_logs(spark.sparkContext, log_level="ERROR")
-
-    # Create a streaming DF from the incoming stream from Kafka
-    df = spark \
-        .readStream \
-        .format("kafka") \
-        .option("kafka.bootstrap.servers", args.servers) \
-        .option("subscribe", args.topic) \
-        .option("startingOffsets", "latest") \
-        .load()
-
-    # keep the size of shuffles small
-    spark.conf.set("spark.sql.shuffle.partitions", "2")
+    # Create a streaming dataframe pointing to a Kafka stream
+    df = connect_with_kafka(
+        servers=args.servers, topic=args.topic,
+        startingoffsets=args.startingoffsets, failondataloss=False)
 
     # Trigger the streaming computation,
     # by defining the sink (memory here) and starting it

--- a/bin/monitor_fromstream.py
+++ b/bin/monitor_fromstream.py
@@ -47,7 +47,7 @@ def main():
     args = parser.parse_args()
 
     # Initialise Spark session
-    spark = init_sparksession(
+    init_sparksession(
         name="archivingStream", shuffle_partitions=2, log_level="ERROR")
 
     # Create a streaming dataframe pointing to a Kafka stream

--- a/bin/simulate_stream.py
+++ b/bin/simulate_stream.py
@@ -23,31 +23,14 @@ import asyncio
 from fink_broker import alertProducer
 from fink_broker import avroUtils
 
+from fink_broker.parser import getargs
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        'broker', type=str,
-        help='Hostname or IP and port of Kafka broker. [KAFKA_IPPORT_SIM]')
-    parser.add_argument(
-        'topic', type=str,
-        help='Name of Kafka topic stream to push to. [KAFKA_TOPIC_SIM]')
-    parser.add_argument(
-        'datapath', type=str,
-        help='Folder containing alerts to be published. [FINK_DATA_SIM]')
-    parser.add_argument(
-        'tinterval', type=float,
-        help='Interval between two alerts (second). [TIME_INTERVAL]')
-    parser.add_argument(
-        'poolsize', type=int,
-        help="""
-Maximum number of alerts to send. If the poolsize is
-bigger than the number of alerts in `datapath`, then we replicate
-the alerts. [POOLSIZE]
-""")
-    args = parser.parse_args()
+    args = getargs(parser)
 
     # Configure producer connection to Kafka broker
-    conf = {'bootstrap.servers': args.broker}
+    conf = {'bootstrap.servers': args.servers}
     streamProducer = alertProducer.AlertProducer(
         args.topic, schema_files=None, **conf)
 
@@ -96,7 +79,7 @@ the alerts. [POOLSIZE]
             loop,
             send_visit,
             files[:args.poolsize],
-            interval=args.tinterval))
+            interval=args.tinterval_kafka))
     loop.run_forever()
     loop.close()
 

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -18,6 +18,11 @@
 KAFKA_IPPORT="134.158.74.95:24499"
 KAFKA_TOPIC="ztf-stream-os"
 
+# From which offset you want to start pulling data. Options are:
+# latest (only new data), earliest (connect from the oldest
+# offset available), or a number (see Spark Kafka integration).
+KAFKA_STARTING_OFFSET="latest"
+
 # Apache Spark mode
 SPARK_MASTER="local[*]"
 

--- a/conf/fink.conf.cluster
+++ b/conf/fink.conf.cluster
@@ -18,6 +18,11 @@
 KAFKA_IPPORT="134.158.74.95:24499"
 KAFKA_TOPIC="ztf-stream-os"
 
+# From which offset you want to start pulling data. Options are:
+# latest (only new data), earliest (connect from the oldest
+# offset available), or a number (see Spark Kafka integration).
+KAFKA_STARTING_OFFSET="earliest"
+
 # Apache Spark mode
 SPARK_MASTER="spark://134.158.75.222:7077"
 

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -18,6 +18,11 @@
 KAFKA_IPPORT="134.158.74.95:24499"
 KAFKA_TOPIC="ztf-stream-os"
 
+# From which offset you want to start pulling data. Options are:
+# latest (only new data), earliest (connect from the oldest
+# offset available), or a number (see Spark Kafka integration).
+KAFKA_STARTING_OFFSET="latest"
+
 # Apache Spark mode
 SPARK_MASTER="local[*]"
 

--- a/python/fink_broker/parser.py
+++ b/python/fink_broker/parser.py
@@ -1,0 +1,96 @@
+# Copyright 2018 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from fink_broker.tester import regular_unit_tests
+
+def getargs(parser):
+    """ Parse command line arguments for fink services
+
+    Parameters
+    ----------
+    parser: argparse.ArgumentParser
+        Empty parser
+
+    Returns
+    ----------
+    args: argparse.Namespace
+        Object containing CLI arguments parsed
+
+    Examples
+    ----------
+    >>> import argparse
+    >>> parser = argparse.ArgumentParser(description=__doc__)
+    >>> args = getargs(parser)
+    >>> print(type(args))
+    <class 'argparse.Namespace'>
+    """
+    parser.add_argument(
+        '-servers', type=str, default='',
+        help='Hostname or IP and port of Kafka broker producing stream. [KAFKA_IPPORT/KAFKA_IPPORT_SIM]')
+    parser.add_argument(
+        '-topic', type=str, default='',
+        help='Name of Kafka topic stream to read from. [KAFKA_TOPIC/KAFKA_TOPIC_SIM]')
+    parser.add_argument(
+        '-schema', type=str, default='',
+        help='Schema to decode the alert. Should be avro file. [FINK_ALERT_SCHEMA]')
+    parser.add_argument(
+        '-startingoffsets', type=str, default='',
+        help='From which offset you want to start pulling data. [KAFKA_STARTING_OFFSET]')
+    parser.add_argument(
+        '-outputpath', type=str, default='',
+        help='Directory on disk for saving live data. [FINK_ALERT_PATH]')
+    parser.add_argument(
+        '-checkpointpath', type=str, default='',
+        help="""
+        For some output sinks where the end-to-end fault-tolerance
+        can be guaranteed, specify the location where the system will
+        write all the checkpoint information. This should be a directory
+        in an HDFS-compatible fault-tolerant file system.
+        See conf/fink.conf & https://spark.apache.org/docs/latest/
+        structured-streaming-programming-guide.html#starting-streaming-queries
+        [FINK_ALERT_CHECKPOINT]
+        """)
+    parser.add_argument(
+        '-finkwebpath', type=str, default='',
+        help='Folder to store UI data for display. [FINK_UI_PATH]')
+    parser.add_argument(
+        '-tinterval', type=int, default=0,
+        help='Time interval between two monitoring. In seconds. [FINK_TRIGGER_UPDATE]')
+    parser.add_argument(
+        '-tinterval_kafka', type=float, default=0.0,
+        help='Time interval between two messages are published. In seconds. [TIME_INTERVAL]')
+    parser.add_argument(
+        '-exit_after', type=int, default=None,
+        help=""" Stop the service after `exit_after` seconds.
+        This primarily for use on Travis, to stop service after some time.
+        Use that with `fink start service --exit_after <time>`. Default is None. """)
+    parser.add_argument(
+        '-datapath', type=str, default='',
+        help='Folder containing alerts to be published by Kafka. [FINK_DATA_SIM]')
+    parser.add_argument(
+        '-poolsize', type=int, default=5,
+        help="""
+Maximum number of alerts to send. If the poolsize is
+bigger than the number of alerts in `datapath`, then we replicate
+the alerts. Default is 5. [POOLSIZE]
+""")
+    args = parser.parse_args(None)
+    return args
+
+
+if __name__ == "__main__":
+    """ Execute the test suite """
+
+    # Run the regular test suite
+    regular_unit_tests(globals())

--- a/python/fink_broker/tester.py
+++ b/python/fink_broker/tester.py
@@ -1,3 +1,4 @@
+import os
 import doctest
 import numpy as np
 
@@ -70,7 +71,7 @@ def spark_unit_tests(global_args=None, verbose=False, withstreaming=False):
 
     conf = SparkConf()
     confdic = {
-        "spark.jars.packages": "org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.0,org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.0,org.apache.spark:spark-avro_2.11:2.4.0",
+        "spark.jars.packages": os.environ["FINK_PACKAGES"],
         "spark.python.daemon.module": "coverage_daemon"}
     conf.setMaster("local[2]")
     conf.setAppName("test")
@@ -86,8 +87,8 @@ def spark_unit_tests(global_args=None, verbose=False, withstreaming=False):
 
     if withstreaming:
         dfstream = spark.readStream.format("kafka")\
-            .option("kafka.bootstrap.servers", "localhost:29092")\
-            .option("subscribe", "ztf-stream-sim")\
+            .option("kafka.bootstrap.servers", os.environ["KAFKA_IPPORT_SIM"])\
+            .option("subscribe", os.environ["KAFKA_TOPIC_SIM"])\
             .option("startingOffsets", "earliest").load()
         global_args["dfstream"] = dfstream
 


### PR DESCRIPTION
Refactor code to avoid code duplication, and allow to pass Kafka starting offset strategy as CLI argument. 

In addition, refactor `fink_test` to:
- Launch the stream to be used for tests inside it (it was done manually prior launching the test suite)
- Pass Kafka parameters from the configuration file to tests directly (via `os.environ["env_var"]`).
- Add common parser for all services.

These changes address: #71, #70, #66, #74, #57 