### PR TITLE
Return also Avro dataframe schema from get_schemas_from_avro. 

### DIFF
--- a/bin/archive.py
+++ b/bin/archive.py
@@ -55,7 +55,7 @@ def main():
         startingoffsets=args.startingoffsets, failondataloss=False)
 
     # Get Schema of alerts
-    alert_schema, alert_schema_json = get_schemas_from_avro(args.schema)
+    _, _, alert_schema_json = get_schemas_from_avro(args.schema)
 
     # Decode the Avro data, and keep only (timestamp, data)
     df_decoded = df.select(

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -48,7 +48,7 @@ def main():
         startingoffsets=args.startingoffsets, failondataloss=False)
 
     # Get Schema of alerts
-    alert_schema, alert_schema_json = get_schemas_from_avro(args.schema)
+    _, _, alert_schema_json = get_schemas_from_avro(args.schema)
 
     # Decode the Avro data, and keep only (timestamp, data)
     df_decoded = df.select(

--- a/bin/simulate_stream.py
+++ b/bin/simulate_stream.py
@@ -31,7 +31,7 @@ def main():
 
     # Configure producer connection to Kafka broker
     conf = {'bootstrap.servers': args.servers}
-    streamProducer = alertProducer.AlertProducer(
+    streamproducer = alertProducer.AlertProducer(
         args.topic, schema_files=None, **conf)
 
     # Scan for avro files
@@ -66,12 +66,12 @@ def main():
             alert_count = 0
             for record in data:
                 if alert_count < 10000:
-                    streamProducer.send(
+                    streamproducer.send(
                         record, alert_schema=schema, encode=True)
                     alert_count += 1
                 else:
                     break
-        streamProducer.flush()
+        streamproducer.flush()
 
     loop = asyncio.get_event_loop()
     asyncio.ensure_future(

--- a/python/fink_broker/sparkUtils.py
+++ b/python/fink_broker/sparkUtils.py
@@ -46,7 +46,7 @@ def from_avro(dfcol, jsonformatschema):
 
     Examples
     ----------
-    >>> alert_schema, alert_schema_json = get_schemas_from_avro(ztf_alert_sample)
+    >>> _, _, alert_schema_json = get_schemas_from_avro(ztf_alert_sample)
 
     >>> df_decoded = dfstream.select(from_avro(dfstream["value"], alert_schema_json).alias("decoded"))
     >>> t = df_decoded.writeStream.queryName("qraw").format("memory").outputMode("update").start()
@@ -218,6 +218,8 @@ def get_schemas_from_avro(avro_path: str):
 
     Returns
     ----------
+    df_schema: pyspark.sql.types.StructType
+        Avro DataFrame schema
     alert_schema: dict
         Schema of the alert as a dictionary (DataFrame Style)
     alert_schema_json: str
@@ -225,7 +227,10 @@ def get_schemas_from_avro(avro_path: str):
 
     Examples
     ----------
-    >>> alert_schema, alert_schema_json = get_schemas_from_avro(ztf_alert_sample)
+    >>> df_schema, alert_schema, alert_schema_json = get_schemas_from_avro(ztf_alert_sample)
+    >>> print(type(df_schema))
+    <class 'pyspark.sql.types.StructType'>
+
     >>> print(type(alert_schema))
     <class 'dict'>
 
@@ -245,7 +250,7 @@ def get_schemas_from_avro(avro_path: str):
         .schema
     alert_schema_json = json.dumps(alert_schema)
 
-    return alert_schema, alert_schema_json
+    return df_schema, alert_schema, alert_schema_json
 
 if __name__ == "__main__":
     """ Execute the test suite with SparkSession initialised """


### PR DESCRIPTION
The routine `get_schemas_from_avro` returns now:

```python
"""
Returns
----------
df_schema: pyspark.sql.types.StructType
    Avro DataFrame schema
alert_schema: dict
    Schema of the alert as a dictionary (DataFrame Style)
alert_schema_json: str
    Schema of the alert as a string (JSON style)
"""
```

A few code smells fixed also.