### PR TITLE
Fix sonar complaints about shallow clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ install:
   - pip install -r requirements.txt
 
 script:
+  # For sonar to run correctly
+  - git fetch --unshallow --quiet
+  
   # Execute tests and report coverage
   - fink start simulator -c ${FINK_HOME}/conf/fink.conf.travis
   - fink_test


### PR DESCRIPTION
Sonar cannot process the coverage files properly when we are using a shallow clone of the repo (which is the case inside the CI). 