### PR TITLE
Issue-73: from base-12 to base-24 for hour partitioning

### DIFF
--- a/bin/archive.py
+++ b/bin/archive.py
@@ -70,7 +70,7 @@ def main():
         .withColumn("year", date_format("timestamp", "yyyy"))\
         .withColumn("month", date_format("timestamp", "MM"))\
         .withColumn("day", date_format("timestamp", "dd"))\
-        .withColumn("hour", date_format("timestamp", "hh"))
+        .withColumn("hour", date_format("timestamp", "HH"))
 
     # Append new rows every `tinterval` seconds
     countquery_tmp = df_partitionedby\


### PR DESCRIPTION
We now use HH for hour instead of hh to parse 24 hour format while archiving and partitioning. Fix #73 