### PR TITLE
Fink commands: fix and new add

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -112,12 +112,12 @@ if [[ $MODE == "stop" ]]; then
     KAFKA_PORT_SIM=${KAFKA_PORT_SIM} docker-compose -p kafkanet -f ${FINK_HOME}/docker/docker-compose-kafka.yml down
   else
     SIGNAL=${SIGNAL:-TERM}
-    PIDS=$(ps ax | grep -i 'fink' | grep -v grep | awk '{print $1}')
+    PIDS=$(ps ax | grep -i 'fink' | grep $service | awk '{print $1}')
 
     if [ -z "$PIDS" ]; then
-      echo "No fink service(s) to stop"
+      echo "No fink $service service to stop"
     else
-      echo "Stopping all services..."
+      echo "Stopping $service..."
       kill -s $SIGNAL $PIDS
     fi
   fi

--- a/bin/fink
+++ b/bin/fink
@@ -50,6 +50,14 @@ while [ "$#" -gt 0 ]; do
         service="$2"
         shift 2
         ;;
+    "show")
+        nservice=$(ps ax | grep -i 'fink start' | grep -v grep | wc -l)
+        echo "$nservice Fink services running: "
+        ps aux | head -1
+        ps aux | grep -i 'fink start' | grep -v grep
+        echo "Use fink stop <service_name> to stop."
+        exit
+        ;;
     -h)
         HELP_ON_SERVICE="-h"
         shift 1

--- a/bin/fink
+++ b/bin/fink
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018 AstroLab Software
+# Copyright 2019 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
 # limitations under the License.
 set -e
 
-message_service="Available services are: dashboard, archive, monitoring, classify"
+message_service="Available services are: dashboard, archive, monitor, classify"
 message_conf="Typical configuration would be $PWD/conf/fink.conf"
 message_help="""
 Monitor Kafka stream received by Apache Spark\n\n
@@ -151,7 +151,7 @@ elif [[ $service == "simulator" ]]; then
   python ${FINK_HOME}/bin/simulate_stream.py \
     -servers ${KAFKA_IPPORT_SIM} -topic ${KAFKA_TOPIC_SIM} -datapath ${FINK_DATA_SIM}\
     -tinterval_kafka ${TIME_INTERVAL} -poolsize ${POOLSIZE} ${HELP_ON_SERVICE}
-elif [[ $service == "monitoring" ]]; then
+elif [[ $service == "monitor" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \

--- a/bin/fink
+++ b/bin/fink
@@ -52,10 +52,11 @@ while [ "$#" -gt 0 ]; do
         ;;
     "show")
         nservice=$(ps ax | grep -i 'fink start' | grep -v grep | wc -l)
-        echo "$nservice Fink services running: "
+        echo "$nservice Fink service(s) running: "
         ps aux | head -1
         ps aux | grep -i 'fink start' | grep -v grep
-        echo "Use fink stop <service_name> to stop."
+        echo "Use <fink stop service_name> to stop a service."
+        echo "Use <fink start dashboard> to start the dashboard or check its status."
         exit
         ;;
     -h)

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018 AstroLab Software
+# Copyright 2019 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,7 +79,7 @@ done
 
 # Integration tests
 if [[ "$NO_INTEGRATION" = false ]] ; then
-  fink start monitoring --exit_after 5 --simulator
+  fink start monitor --exit_after 5 --simulator
   fink start archive --exit_after 30 --simulator
   fink start classify --exit_after 30 --simulator
   fink start dashboard

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,18 @@ fink start simulator
 ```
 Now go to `http://localhost:5000/live.html` and see the alerts coming! The dashboard
 should refresh automatically, but do it manually in case it does not work.
+
+You can easily see the running services by using:
+
+```bash
+fink show
+1 Fink service(s) running:
+USER               PID  %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND
+julien           61200   0.0  0.0  4277816   1232 s001  S     8:20am   0:00.01 /bin/bash /path/to/fink start monitor --simulator
+Use <fink stop service_name> to stop a service.
+Use <fink start dashboard> to start the dashboard or check its status.
+```
+
 Finally stop monitoring and shut down the UI simply using:
 ```bash
 fink stop monitor

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ fink start dashboard
 
 Connect the monitoring service to the stream:
 ```bash
-fink start monitoring --simulator > live.log &
+fink start monitor --simulator > live.log &
 ```
 
 Send a small burst of alerts:
@@ -84,7 +84,7 @@ Now go to `http://localhost:5000/live.html` and see the alerts coming! The dashb
 should refresh automatically, but do it manually in case it does not work.
 Finally stop monitoring and shut down the UI simply using:
 ```bash
-fink stop monitoring
+fink stop monitor
 fink stop dashboard
 ```
 
@@ -104,6 +104,6 @@ Monitor Kafka stream received by Apache Spark
  To get help for a service:
  	fink start <service> -h
 
- Available services are: dashboard, archive, monitoring, classify
+ Available services are: dashboard, archive, monitor, classify
  Typical configuration would be ${FINK_HOME}/conf/fink.conf
 ```

--- a/docs/user_guide/available-services.md
+++ b/docs/user_guide/available-services.md
@@ -45,7 +45,7 @@ The monitoring of the stream is typically done with the archiving service. But f
 To use this service, just execute:
 
 ```bash
-fink start monitoring > live.log &
+fink start monitor > live.log &
 ```
 Again, this will query the stream directly - so be careful!
 

--- a/docs/user_guide/howto.md
+++ b/docs/user_guide/howto.md
@@ -95,7 +95,7 @@ Monitor Kafka stream received by Apache Spark
  To get help for a service:
  	fink start <service> -h
 
- Available services are: dashboard, archive, monitoring, classify
+ Available services are: dashboard, archive, monitor, classify
  Typical configuration would be ${FINK_HOME}/conf/fink.conf
 ```
 
@@ -137,24 +137,64 @@ You easily get help on a service using:
 fink start <service_name> -h
 ```
 
-This will also tells you which configuration parameters are used, e.g.
+This will also tells you which configuration parameters can be used, e.g.
 
-```bash
-fink start monitoring -h
-usage: monitor_fromstream.py [-h] servers topic finkwebpath
+```shell
+fink start monitor -h
+usage: monitor_fromstream.py [-h] [-servers SERVERS] [-topic TOPIC]
+                             [-schema SCHEMA]
+                             [-startingoffsets STARTINGOFFSETS]
+                             [-outputpath OUTPUTPATH]
+                             [-checkpointpath CHECKPOINTPATH]
+                             [-finkwebpath FINKWEBPATH] [-tinterval TINTERVAL]
+                             [-tinterval_kafka TINTERVAL_KAFKA]
+                             [-exit_after EXIT_AFTER] [-datapath DATAPATH]
+                             [-poolsize POOLSIZE]
 
 Monitor Kafka stream received by Spark
 
-positional arguments:
-  servers      Hostname or IP and port of Kafka broker producing stream.
-               [KAFKA_IPPORT]
-  topic        Name of Kafka topic stream to read from. [KAFKA_TOPIC]
-  finkwebpath  Folder to store UI data for display. [FINK_UI_PATH]
-
 optional arguments:
-  -h, --help   show this help message and exit
+  -h, --help            show this help message and exit
+  -servers SERVERS      Hostname or IP and port of Kafka broker producing
+                        stream. [KAFKA_IPPORT/KAFKA_IPPORT_SIM]
+  -topic TOPIC          Name of Kafka topic stream to read from.
+                        [KAFKA_TOPIC/KAFKA_TOPIC_SIM]
+  -schema SCHEMA        Schema to decode the alert. Should be avro file.
+                        [FINK_ALERT_SCHEMA]
+  -startingoffsets STARTINGOFFSETS
+                        From which offset you want to start pulling data.
+                        [KAFKA_STARTING_OFFSET]
+  -outputpath OUTPUTPATH
+                        Directory on disk for saving live data.
+                        [FINK_ALERT_PATH]
+  -checkpointpath CHECKPOINTPATH
+                        For some output sinks where the end-to-end fault-
+                        tolerance can be guaranteed, specify the location
+                        where the system will write all the checkpoint
+                        information. This should be a directory in an HDFS-
+                        compatible fault-tolerant file system. See
+                        conf/fink.conf & https://spark.apache.org/docs/latest/
+                        structured-streaming-programming-guide.html#starting-
+                        streaming-queries [FINK_ALERT_CHECKPOINT]
+  -finkwebpath FINKWEBPATH
+                        Folder to store UI data for display. [FINK_UI_PATH]
+  -tinterval TINTERVAL  Time interval between two monitoring. In seconds.
+                        [FINK_TRIGGER_UPDATE]
+  -tinterval_kafka TINTERVAL_KAFKA
+                        Time interval between two messages are published. In
+                        seconds. [TIME_INTERVAL]
+  -exit_after EXIT_AFTER
+                        Stop the service after `exit_after` seconds. This
+                        primarily for use on Travis, to stop service after
+                        some time. Use that with `fink start service
+                        --exit_after <time>`. Default is None.
+  -datapath DATAPATH    Folder containing alerts to be published by Kafka.
+                        [FINK_DATA_SIM]
+  -poolsize POOLSIZE    Maximum number of alerts to send. If the poolsize is
+                        bigger than the number of alerts in `datapath`, then
+                        we replicate the alerts. Default is 5. [POOLSIZE]
 ```
-
+Note that not all of them are in used in all services (but they all share the same parser).
 ### Spark's verbosity is overwhelming my logs!
 
 Yes... By default Apache Spark outputs many many things - good for debug, but awful in production. In Fink we provide a utils to deal with Spark logs in your service:
@@ -243,4 +283,5 @@ You forgot to set `FINK_HOME`. The best is to add the path to Fink in your `.bas
 # in ~/.bash_profile
 export FINK_HOME=/path/to/fink-broker
 export PYTHONPATH=$FINK_HOME/python:$PYTHONPATH
+export PATH=$FINK_HOME/bin:$PATH
 ```

--- a/docs/user_guide/howto.md
+++ b/docs/user_guide/howto.md
@@ -195,6 +195,20 @@ optional arguments:
                         we replicate the alerts. Default is 5. [POOLSIZE]
 ```
 Note that not all of them are in used in all services (but they all share the same parser).
+
+### How do I see how many services are running?
+
+You can easily see the running services by using:
+
+```bash
+fink show
+1 Fink service(s) running:
+USER               PID  %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND
+julien           61200   0.0  0.0  4277816   1232 s001  S     8:20am   0:00.01 /bin/bash /path/to/fink start monitor --simulator
+Use <fink stop service_name> to stop a service.
+Use <fink start dashboard> to start the dashboard or check its status.
+```
+
 ### Spark's verbosity is overwhelming my logs!
 
 Yes... By default Apache Spark outputs many many things - good for debug, but awful in production. In Fink we provide a utils to deal with Spark logs in your service:

--- a/docs/user_guide/simulator.md
+++ b/docs/user_guide/simulator.md
@@ -33,7 +33,7 @@ fink start <service> --simulator
 For example for demo purposing, you can easily start the monitoring service on the simulated stream with:
 
 ```bash
-fink start monitoring --simulator > live_sim.log &
+fink start monitor --simulator > live_sim.log &
 ```
 
 and watch the stream at [http://localhost:5000/live.html](http://localhost:5000/live.html) (change the port with the one in your configuration file).


### PR DESCRIPTION
This PR updates the `fink` binary with one bug fix and one new command:
- one can now stop services by their name: `fink stop <service name>`
- one can now see the list of fink services running: `fink show`

Also, the service previously named `monitoring` has been renamed into `monitor`. 
The documentation has been updated accordingly.
