### PR TITLE
Change python to python3 in the fink binary when launching the simulator

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -157,7 +157,7 @@ elif [[ $service == "simulator" ]]; then
     echo "docker-compose not found"
     exit
   fi
-  python ${FINK_HOME}/bin/simulate_stream.py \
+  python3 ${FINK_HOME}/bin/simulate_stream.py \
     -servers ${KAFKA_IPPORT_SIM} -topic ${KAFKA_TOPIC_SIM} -datapath ${FINK_DATA_SIM}\
     -tinterval_kafka ${TIME_INTERVAL} -poolsize ${POOLSIZE} ${HELP_ON_SERVICE}
 elif [[ $service == "monitor" ]]; then


### PR DESCRIPTION
There is often confusion for users. Fink is using python3 exclusively, and to avoid any confusion it is made explicit in the binary. Note that pyspark implicitly assumes the use of python3 here.