### PR TITLE
Split Spark extra option and Kafka parameters in configuration files

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -164,7 +164,7 @@ elif [[ $service == "monitor" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
-    ${EXTRA_SPARK_CONFIG} \
+    ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/monitor_fromstream.py -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
     -startingoffsets ${KAFKA_STARTING_OFFSET} -finkwebpath ${FINK_UI_PATH} \
     ${EXIT_AFTER} ${HELP_ON_SERVICE}
@@ -172,7 +172,7 @@ elif [[ $service == "classify" ]]; then
   # Aggregate the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
-    ${EXTRA_SPARK_CONFIG} \
+    ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/classify_fromstream.py -servers ${KAFKA_IPPORT} \
     -topic ${KAFKA_TOPIC} -schema ${FINK_ALERT_SCHEMA} -startingoffsets ${KAFKA_STARTING_OFFSET} \
     -finkwebpath ${FINK_UI_PATH} -tinterval ${FINK_TRIGGER_UPDATE} \
@@ -181,7 +181,7 @@ elif [[ $service == "archive" ]]; then
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
-    ${EXTRA_SPARK_CONFIG} \
+    ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/archive.py -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
     -schema ${FINK_ALERT_SCHEMA} -startingoffsets ${KAFKA_STARTING_OFFSET} \
     -outputpath ${FINK_ALERT_PATH} -checkpointpath ${FINK_ALERT_CHECKPOINT} \

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -26,8 +26,11 @@ KAFKA_STARTING_OFFSET="latest"
 # Apache Spark mode
 SPARK_MASTER="local[*]"
 
-# Should be Spark options actually (to allow cluster resources!)
+# Should be Spark options actually (cluster resources, ...)
 EXTRA_SPARK_CONFIG=""
+
+# Should be Kafka secured options actually (to allow connection to Kafka)
+SECURED_KAFKA_CONFIG=''
 
 # These are the Maven Coordinates of dependencies for Fink
 # Change the version according to your Spark version.

--- a/conf/fink.conf.cluster
+++ b/conf/fink.conf.cluster
@@ -26,8 +26,11 @@ KAFKA_STARTING_OFFSET="earliest"
 # Apache Spark mode
 SPARK_MASTER="spark://134.158.75.222:7077"
 
-# Should be Spark options actually (to allow cluster resources!)
+# Should be Spark options actually (cluster resources, ...)
 EXTRA_SPARK_CONFIG="--driver-memory 4g --executor-memory 30g --executor-cores 17 --total-executor-cores 51"
+
+# Should be Kafka secured options actually (to allow connection to Kafka)
+SECURED_KAFKA_CONFIG=''
 
 # These are the Maven Coordinates of dependencies for Fink
 # Change the version according to your Spark version.

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -26,8 +26,11 @@ KAFKA_STARTING_OFFSET="latest"
 # Apache Spark mode
 SPARK_MASTER="local[*]"
 
-# Should be Spark options actually (to allow cluster resources!)
+# Should be Spark options actually (cluster resources, ...)
 EXTRA_SPARK_CONFIG=""
+
+# Should be Kafka secured options actually (to allow connection to Kafka)
+SECURED_KAFKA_CONFIG=''
 
 # These are the Maven Coordinates of dependencies for Fink
 # Change the version according to your Spark version.


### PR DESCRIPTION
Following #90, Spark & Kafka options to spark-submit are split. This improves readability. 