### PR TITLE
Updating path to Spark binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 
 install:
   # Download spark 2.4.0
-  - "[ -f spark ] || mkdir spark && cd spark && axel http://www-us.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz && cd .."
+  - "[ -f spark ] || mkdir spark && cd spark && axel http://archive.apache.org/dist/spark/spark-2.4.0/spark-2.4.0-bin-hadoop2.7.tgz && cd .."
   - tar -xf ./spark/spark-2.4.0-bin-hadoop2.7.tgz
   - export SPARK_HOME=`pwd`/spark-2.4.0-bin-hadoop2.7
   - echo "spark.yarn.jars=${SPARK_HOME}/jars/*.jar" > ${SPARK_HOME}/conf/spark-defaults.conf
@@ -41,7 +41,7 @@ install:
 script:
   # For sonar to run correctly
   - git fetch --unshallow --quiet
-  
+
   # Execute tests and report coverage
   - fink start simulator -c ${FINK_HOME}/conf/fink.conf.travis
   - fink_test


### PR DESCRIPTION
Previous link throws 404 Not Found error. Alternative link provided to
allow for Apache Spark download

This fixes issue #104.

It was discovered that the original link to `spark-2.4.0-bin-hadoop2.7.tgz` was
throwing `404 Not Found` error. An alternative link is presented here to pull
down binary.

Minimal change to `.travis.yml` file with update to path