### PR TITLE
Updating gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cov.txt
 htmlcov
 old
 datasim/*.avro
+
+archive/
+web/data/


### PR DESCRIPTION
Do not track:
    archive/
    web/data/

${FINK_HOME}/web/data is created the first time fink is launched, and
${FINK_HOME}/archive (or actually whatever folder is specified under
FINK_ALERT_PATH) is created first when calling fink start archive.

Fixes #110 