### PR TITLE
Disable sonar analysis for PR from fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,7 @@ script:
 
   # Scan with sonarqube only if internal PR (i.e. no fork)
   # Note: this is unsatisfactory...
-  - |
-  if [ $TRAVIS_REPO_SLUG == "astrolabsoftware/fink-broker" ]; then
+  - if [ $TRAVIS_REPO_SLUG == "astrolabsoftware/fink-broker" ]; then
     coverage xml -i;
     sonar-scanner;
-  fi
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,10 @@ script:
   - fink_test
   - bash <(curl -s https://codecov.io/bash)
 
-  # Scan with sonarqube
-  - coverage xml -i
-  - sonar-scanner
+  # Scan with sonarqube only if internal PR (i.e. no fork)
+  # Note: this is unsatisfactory...
+  - |
+  if [ $TRAVIS_REPO_SLUG == "astrolabsoftware/fink-broker" ]; then
+    coverage xml -i;
+    sonar-scanner;
+  fi


### PR DESCRIPTION
See #116 - but currently SonarQube cannot inspect PR that originates from forks :-(