### PR TITLE
Fix typo while checking for external PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
 
   # Scan with sonarqube only if internal PR (i.e. no fork)
   # Note: this is unsatisfactory...
-  - if [ $TRAVIS_REPO_SLUG == "astrolabsoftware/fink-broker" ]; then
+  - if [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-broker" ]; then
     coverage xml -i;
     sonar-scanner;
     fi


### PR DESCRIPTION
This PR fixes a typo found in travis concerning disabling Sonarqube analysis for PR coming from forks.