### PR TITLE
Issue 99: Connect to earliest offsets in tests

### DIFF
--- a/bin/fink_test
+++ b/bin/fink_test
@@ -79,10 +79,10 @@ done
 
 # Integration tests
 if [[ "$NO_INTEGRATION" = false ]] ; then
-  fink start monitor --exit_after 5 --simulator
-  fink start archive --exit_after 30 --simulator
-  fink start classify --exit_after 30 --simulator
-  fink start dashboard
+  fink start monitor --exit_after 30 --simulator -c conf/fink.conf.travis
+  fink start archive --exit_after 30 --simulator -c conf/fink.conf.travis
+  fink start classify --exit_after 30 --simulator -c conf/fink.conf.travis
+  fink start dashboard -c conf/fink.conf.travis
 fi
 
 # Combine individual reports in one

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -21,7 +21,7 @@ KAFKA_TOPIC=""
 # From which offset you want to start pulling data. Options are:
 # latest (only new data), earliest (connect from the oldest
 # offset available), or a number (see Spark Kafka integration).
-KAFKA_STARTING_OFFSET="latest"
+KAFKA_STARTING_OFFSET="earliest"
 
 # Apache Spark mode
 SPARK_MASTER="local[*]"


### PR DESCRIPTION
Force tests to connect to the `earliest` Kafka offset in order to really process data (and not just test the connection to the stream). Fix also the configuration file to `conf/fink.conf.travis` in the integration tests.