### PR TITLE
Issue 130: print version number from the binary

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -83,6 +83,10 @@ while [ "$#" -gt 0 ]; do
         SIM_ONLY=true
         shift 1
         ;;
+    --version)
+        python3 -c "import fink_broker; print(fink_broker.__version__)"
+        exit
+        ;;
     --exit_after)
         EXIT_AFTER="-exit_after $2"
         shift 2


### PR DESCRIPTION
Linked to issue(s): #130 

## What changes were proposed in this pull request?

This PR adds an argument to `fink` binary to print the version number of the code:
```
fink --version
0.1.1
```

## How was this patch tested?

Manually.