### PR TITLE
update the gitignore to stop tracking .coverage* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 *.log
-.coverage
+.coverage*
 __pycache__
 cov.txt
 htmlcov


### PR DESCRIPTION

Linked to issue(s): #135 

## What changes were proposed in this pull request?
gitignore has been updated to stop tracking files of the general pattern .coverage*