### PR TITLE
Issue 145: Add database connector

### DIFF
--- a/bin/archive.py
+++ b/bin/archive.py
@@ -35,7 +35,7 @@ import time
 from fink_broker.parser import getargs
 
 from fink_broker.sparkUtils import from_avro
-from fink_broker.sparkUtils import init_sparksession, connect_with_kafka
+from fink_broker.sparkUtils import init_sparksession, connect_to_kafka
 from fink_broker.sparkUtils import get_schemas_from_avro
 
 from fink_broker.monitoring import monitor_progress_webui
@@ -49,7 +49,7 @@ def main():
         name="archivingStream", shuffle_partitions=2, log_level="ERROR")
 
     # Create a streaming dataframe pointing to a Kafka stream
-    df = connect_with_kafka(
+    df = connect_to_kafka(
         servers=args.servers, topic=args.topic,
         startingoffsets=args.startingoffsets, failondataloss=False)
 

--- a/bin/classify_fromstream.py
+++ b/bin/classify_fromstream.py
@@ -27,7 +27,7 @@ from fink_broker.parser import getargs
 
 from fink_broker.sparkUtils import from_avro
 from fink_broker.sparkUtils import write_to_csv
-from fink_broker.sparkUtils import init_sparksession, connect_with_kafka
+from fink_broker.sparkUtils import init_sparksession, connect_to_kafka
 from fink_broker.sparkUtils import get_schemas_from_avro
 
 from fink_broker.classification import cross_match_alerts_per_batch
@@ -42,7 +42,7 @@ def main():
         name="classifyStream", shuffle_partitions=2, log_level="ERROR")
 
     # Create a streaming dataframe pointing to a Kafka stream
-    df = connect_with_kafka(
+    df = connect_to_kafka(
         servers=args.servers, topic=args.topic,
         startingoffsets=args.startingoffsets, failondataloss=False)
 

--- a/bin/monitor_fromstream.py
+++ b/bin/monitor_fromstream.py
@@ -22,7 +22,7 @@ import time
 
 from fink_broker.parser import getargs
 
-from fink_broker.sparkUtils import init_sparksession, connect_with_kafka
+from fink_broker.sparkUtils import init_sparksession, connect_to_kafka
 
 from fink_broker.monitoring import monitor_progress_webui
 
@@ -35,7 +35,7 @@ def main():
         name="monitoringStream", shuffle_partitions=2, log_level="ERROR")
 
     # Create a streaming dataframe pointing to a Kafka stream
-    df = connect_with_kafka(
+    df = connect_to_kafka(
         servers=args.servers, topic=args.topic,
         startingoffsets=args.startingoffsets, failondataloss=False)
 


### PR DESCRIPTION
Linked to issue(s): #145 

## What changes were proposed in this pull request?

This PR renames the routine `connect_with_kafka` into `connect_to_kafka`, and introduces a new routine `connect_to_raw_database` to ease the connection to the raw (Parquet) database.

## How was this patch tested?

A new unit test has been added.
