### PR TITLE
Issue 158: flatten DataFrame columns before sending to the science database

### DIFF
--- a/python/fink_broker/sparkUtils.py
+++ b/python/fink_broker/sparkUtils.py
@@ -280,7 +280,7 @@ def connect_to_raw_database(
         .getOrCreate()
 
     # Create a DF from the database
-    userschema = spark.read.format("parquet").load(basepath).schema
+    userschema = spark.read.format("parquet").load(path).schema
     df = spark \
         .readStream \
         .format("parquet") \


### PR DESCRIPTION
Linked to issue(s): #158 

## What changes were proposed in this pull request?

This PR fixes a bug in the parquet reader, that was preventing the column flattening (schema mismatch). This PR also introduces tools to flatten the columns of a DataFrame:
- one column of type struct with n scalar entries becomes n columns with scalar type.
- one column of type array of n structs becomes n columns with array of elements.

## How was this patch tested?

Manually using tests in place