### PR TITLE
Issue 171: re-introduce the monitoring service (checkstream)

### DIFF
--- a/bin/checkstream.py
+++ b/bin/checkstream.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# Copyright 2019 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Monitor Kafka stream received by Spark
+"""
+from pyspark.sql import SparkSession
+
+import argparse
+import time
+
+from fink_broker.parser import getargs
+
+from fink_broker.sparkUtils import init_sparksession, connect_to_kafka
+
+from fink_broker.monitoring import monitor_progress_webui
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = getargs(parser)
+
+    # Initialise Spark session
+    init_sparksession(
+        name="checkStream", shuffle_partitions=2, log_level="ERROR")
+
+    # Create a streaming dataframe pointing to a Kafka stream
+    df = connect_to_kafka(
+        servers=args.servers, topic=args.topic,
+        startingoffsets=args.startingoffsets_stream, failondataloss=False)
+
+    # Trigger the streaming computation,
+    # by defining the sink (memory here) and starting it
+    countquery = df \
+        .writeStream \
+        .queryName("qraw")\
+        .format("console")\
+        .outputMode("update") \
+        .start()
+
+    # Monitor the progress of the stream, and save data for the webUI
+    colnames = ["inputRowsPerSecond", "processedRowsPerSecond", "timestamp"]
+    monitor_progress_webui(
+        countquery,
+        2,
+        colnames,
+        args.finkwebpath, "live.csv", "live")
+
+    # Keep the Streaming running until something or someone ends it!
+    if args.exit_after is not None:
+        time.sleep(args.exit_after)
+        countquery.stop()
+        print("Exiting the checkstream service normally...")
+    else:
+        countquery.awaitTermination()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/fink
+++ b/bin/fink
@@ -15,10 +15,10 @@
 # limitations under the License.
 set -e
 
-message_service="Available services are: dashboard, stream2raw, raw2science"
+message_service="Available services are: dashboard, checkstream, stream2raw, raw2science"
 message_conf="Typical configuration would be $PWD/conf/fink.conf"
 message_help="""
-Monitor Kafka stream received by Apache Spark\n\n
+Handle Kafka stream received by Apache Spark\n\n
 Usage:\n
     \tto start: fink start <service> [-h] [-c <conf>] [--simulator]\n
     \tto stop : fink stop  <service> [-h] [-c <conf>]\n\n
@@ -180,6 +180,14 @@ elif [[ $service == "simulator" ]]; then
   python3 ${FINK_HOME}/bin/simulate_stream.py \
     -servers ${KAFKA_IPPORT_SIM} -topic ${KAFKA_TOPIC_SIM} -datasimpath ${FINK_DATA_SIM}\
     -tinterval_kafka ${TIME_INTERVAL} -poolsize ${POOLSIZE} ${HELP_ON_SERVICE}
+elif [[ $service == "checkstream" ]]; then
+  # Monitor the stream of alerts
+  spark-submit --master ${SPARK_MASTER} \
+    --packages ${FINK_PACKAGES} \
+    ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
+    ${FINK_HOME}/bin/checkstream.py -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
+    -startingoffsets_stream ${KAFKA_STARTING_OFFSET} -finkwebpath ${FINK_UI_PATH} \
+    ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "stream2raw" ]]; then
 
   # Store the stream of alerts

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -112,6 +112,9 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   # Fire a stream
   fink start simulator -c $conf
 
+  # Check the stream is there
+  fink start checkstream --exit_after 30 --simulator -c $conf
+
   # Connect the service to build the raw database from the stream
   fink start stream2raw --exit_after 50 --simulator -c $conf
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ Both the [dashboard](user_guide/dashboard.md) and the [simulator](user_guide/sim
 
 ## Getting started
 
-Before running the test suite download the ZTF data for simulation. Go to the datasim directory and execute the download script:
+The repository contains some alerts from the ZTF experiment required for the test suite in the folder `datasim`. If you need to download more alerts data, go to the datasim directory and execute the download script:
 
 ```bash
 cd datasim
@@ -83,14 +83,13 @@ cd datasim
 cd ..
 ```
 
-Now, make sure the test suite is running fine. Just execute:
+Make sure the test suite is running fine. Just execute:
 
 ```bash
 fink_test [--without-integration] [-h]
 ```
 
-You should see plenty of Spark logs (and yet we have shut most of them!), but no failures hopefully! Success is silent, and the coverage is printed on screen at the end. You can disable integration tests by specifying the argument `--without-integration`. Then let's test some functionalities of Fink by simulating a stream of alert, and monitoring it
-via the dashboard. Start the dashboard, and go to `http://localhost:5000`:
+You should see plenty of Spark logs (and yet we have shut most of them!), but no failures hopefully! Success is silent, and the coverage is printed on screen at the end. You can disable integration tests by specifying the argument `--without-integration`. Then let's test some functionalities of Fink by simulating a stream of alert, and monitoring it via the dashboard. Start the dashboard, and go to `http://localhost:5000`:
 ```bash
 fink start dashboard
 # Creating dashboardnet_website_1 ... done
@@ -99,7 +98,7 @@ fink start dashboard
 
 Connect the monitoring service to the stream:
 ```bash
-fink start monitor --simulator > live.log &
+fink start checkstream --simulator > live.log &
 ```
 
 Send a small burst of alerts:
@@ -115,14 +114,14 @@ You can easily see the running services by using:
 fink show
 1 Fink service(s) running:
 USER               PID  %CPU %MEM      VSZ    RSS   TT  STAT STARTED      TIME COMMAND
-julien           61200   0.0  0.0  4277816   1232 s001  S     8:20am   0:00.01 /bin/bash /path/to/fink start monitor --simulator
+julien           61200   0.0  0.0  4277816   1232 s001  S     8:20am   0:00.01 /bin/bash /path/to/fink start checkstream --simulator
 Use <fink stop service_name> to stop a service.
 Use <fink start dashboard> to start the dashboard or check its status.
 ```
 
 Finally stop monitoring and shut down the UI simply using:
 ```bash
-fink stop monitor
+fink stop checkstream
 fink stop dashboard
 ```
 
@@ -130,7 +129,7 @@ To get help about `fink`, just type:
 
 ```shell
 fink
-Monitor Kafka stream received by Apache Spark
+Handle Kafka stream received by Apache Spark
 
  Usage:
  	to start: fink start <service> [-h] [-c <conf>] [--simulator]
@@ -142,6 +141,9 @@ Monitor Kafka stream received by Apache Spark
  To get help for a service:
  	fink start <service> -h
 
- Available services are: dashboard, archive, monitor, classify
+ To see the running processes:
+  fink show
+
+ Available services are: dashboard, checkstream, stream2raw, raw2science
  Typical configuration would be ${FINK_HOME}/conf/fink.conf
 ```


### PR DESCRIPTION
Linked to issue(s): #171 

## What changes were proposed in this pull request?

This PR re-introduces a service to monitor the stream (compute alert rates for a given topic):

```bash
fink start checkstream
```

## How was this patch tested?

Manually
