### PR TITLE
Updating travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: xenial
 
 # Check against N & N-1 Spark versions
 env:
-  - SPARK_VERSION=2.4.0
   - SPARK_VERSION=2.4.1
   - SPARK_VERSION=2.4.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dist: xenial
 env:
   - SPARK_VERSION=2.4.0
   - SPARK_VERSION=2.4.1
+  - SPARK_VERSION=2.4.3
 
 python:
   - "3.6"

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -36,9 +36,9 @@ SECURED_KAFKA_CONFIG=''
 # Change the version according to your Spark version.
 # NOTE: HBase packages are not required for Parquet archiving
 FINK_PACKAGES=\
-org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.0,\
-org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.0,\
-org.apache.spark:spark-avro_2.11:2.4.0,\
+org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.1,\
+org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.1,\
+org.apache.spark:spark-avro_2.11:2.4.1,\
 org.apache.hbase:hbase-client:2.1.4,\
 org.apache.hbase:hbase-common:2.1.4,\
 org.apache.hbase:hbase-mapreduce:2.1.4

--- a/conf/fink.conf.cluster
+++ b/conf/fink.conf.cluster
@@ -36,9 +36,9 @@ SECURED_KAFKA_CONFIG=''
 # Change the version according to your Spark version.
 # NOTE: HBase packages are not required for Parquet archiving
 FINK_PACKAGES=\
-org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.0,\
-org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.0,\
-org.apache.spark:spark-avro_2.11:2.4.0,\
+org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.1,\
+org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.1,\
+org.apache.spark:spark-avro_2.11:2.4.1,\
 org.apache.hbase:hbase-client:2.1.4,\
 org.apache.hbase:hbase-common:2.1.4,\
 org.apache.hbase:hbase-mapreduce:2.1.4

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -36,9 +36,9 @@ SECURED_KAFKA_CONFIG=''
 # Change the version according to your Spark version.
 # NOTE: HBase packages are not required for Parquet archiving
 FINK_PACKAGES=\
-org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.0,\
-org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.0,\
-org.apache.spark:spark-avro_2.11:2.4.0,\
+org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.1,\
+org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.1,\
+org.apache.spark:spark-avro_2.11:2.4.1,\
 org.apache.hbase:hbase-client:2.1.4,\
 org.apache.hbase:hbase-common:2.1.4,\
 org.apache.hbase:hbase-mapreduce:2.1.4

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -64,9 +64,9 @@ Note that while Apache Avro is supported natively since Spark 2.4, you still nee
 # These are the Maven Coordinates of dependencies for Fink
 # Change the version according to your Spark version.
 FINK_PACKAGES=\
-org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.0,\
-org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.0,\
-org.apache.spark:spark-avro_2.11:2.4.0
+org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.1,\
+org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.1,\
+org.apache.spark:spark-avro_2.11:2.4.1
 ```
 
 In addition to packages, you can specify external libraries as jars:


### PR DESCRIPTION
Adding SPARK_VERSION = 2.4.3 to matrix of Spark versions to run CI tests
against.

As mentioned in #157; Spark 2.4.2 is shipped for Scala 2.12 by default
(need to recompile for Scala 2.11), hence we won't test against it.

**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #157 

## What changes were proposed in this pull request?
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

How is the issue this PR is referenced against solved with this PR?

`.travis.yml` file has been updated to include `SPARK_VERSION = 2.4.3`

## How was this patch tested?

With a successful build on Travis CI: https://travis-ci.com/tallamjr/fink-broker/builds/114230682