### PR TITLE
Switch from custom HBase sink provider to foreachBatch mechanism

### DIFF
--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -99,7 +99,7 @@ def main():
         ui_refresh,
         colnames,
         args.finkwebpath,
-        "live.csv",
+        "live_raw.csv",
         "live")
 
     monitor_progress_webui(

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 coverage:
+  precision: 0
   status:
     project:
       default:

--- a/python/fink_broker/sparkUtils.py
+++ b/python/fink_broker/sparkUtils.py
@@ -76,7 +76,8 @@ def write_to_csv(
     Parameters
     ----------
     batchdf: DataFrame
-        Static Spark DataFrame with stream data
+        Static Spark DataFrame with stream data. Expect 2 columns
+        with variable names and their count.
     batchid: int
         ID of the batch.
     fn: str, optional
@@ -89,7 +90,7 @@ def write_to_csv(
     >>> write_to_csv(df, 0, fn="test.csv")
     >>> os.remove("test.csv")
     """
-    batchdf.select(["type", "count"])\
+    batchdf\
         .toPandas()\
         .to_csv(fn, index=False)
     batchdf.unpersist()

--- a/python/fink_broker/sparkUtils.py
+++ b/python/fink_broker/sparkUtils.py
@@ -280,7 +280,11 @@ def connect_to_raw_database(
         .getOrCreate()
 
     # Create a DF from the database
-    userschema = spark.read.format("parquet").load(path).schema
+    userschema = spark\
+            .read\
+            .parquet(basepath)\
+            .schema
+
     df = spark \
         .readStream \
         .format("parquet") \

--- a/web/js/live.js
+++ b/web/js/live.js
@@ -1,4 +1,4 @@
-var defaultData = window.location.origin + '/data/live.csv'
+var defaultData = window.location.origin + '/data/live_raw.csv'
 var urlInput = document.getElementById('fetchURL');
 var pollingCheckbox = document.getElementById('enablePolling');
 var pollingInput = document.getElementById('pollingTime');


### PR DESCRIPTION
Linked to issue(s): #178 

## What changes were proposed in this pull request?

This PR changes the way we input data into the science database. We used to use a custom HBase sink provider for Spark Structured Streaming. This had many limitations, and it is now replaced with a new method using `foreachBatch` (new in Spark 2.4). With this new method, we can use any standard HBase DataFrame connector as the `foreachBatch` method works on the micro-batch DataFrame directly.

## How was this patch tested?

Manually on a laptop (macos 10.14.5).