### PR TITLE
Issue 185: Add a new tab to the dashboard (xmatch)

### DIFF
--- a/web/about.html
+++ b/web/about.html
@@ -15,6 +15,7 @@
     <a href="/index.html">Fink</a>
     <a href="/live.html">Live</a>
     <a href="/history.html">History</a>
+    <a href="/classification.html">Classification</a>
     <a href="/skymap.html">Sky map</a>
     <a class="active" href="/about.html">About</a>
   </div>

--- a/web/classification.html
+++ b/web/classification.html
@@ -15,6 +15,7 @@
     <script src="https://code.highcharts.com/modules/data.js"></script>
     <script src="https://code.highcharts.com/highcharts-more.js"></script>
     <script src="https://code.highcharts.com/modules/exporting.js"></script>
+    <script src="https://code.highcharts.com/modules/funnel.js"></script>
     <!-- <script src="https://code.highcharts.com/themes/grid-light.js"></script> -->
     <!-- <script src="https://code.highcharts.com/themes/dark-blue.js"></script> -->
     <!-- <script src="https://code.highcharts.com/themes/gray.js"></script> -->
@@ -33,11 +34,14 @@
       <a href="/about.html">About</a>
     </div>
 
+    <div id="projection">
+      <button onClick="choose('plain')">Plain</button>
+      <button onClick="choose('polar')">Polar</button>
+      <!-- <button onClick="choose('pyramid')">Pyramid</button> -->
+    </div>
     <div id="container_bar"></div>
     <script src="js/bar.js"></script>
-    <!-- <button id="plain">Plain</button>
-    <button id="inverted">Inverted</button>
-    <button id="polar">Polar</button> -->
+
 
     <!-- Footer -->
     <div id="footer" class="container text-center">

--- a/web/history.html
+++ b/web/history.html
@@ -30,6 +30,7 @@
       <a href="/index.html">Fink</a>
       <a href="/live.html">Live</a>
       <a class="active" href="/history.html">History</a>
+      <a href="/classification.html">Classification</a>
       <a href="/skymap.html">Sky map</a>
       <a href="/about.html">About</a>
     </div>

--- a/web/index.html
+++ b/web/index.html
@@ -18,6 +18,7 @@
       <a class="active" href="/index.html">Fink &#8594;</a>
       <a href="/live.html">Live</a>
       <a href="/history.html">History</a>
+      <a href="/classification.html">Classification</a>
       <a href="/skymap.html">Sky map</a>
       <a href="/about.html">About</a>
       </div>

--- a/web/js/bar.js
+++ b/web/js/bar.js
@@ -1,0 +1,153 @@
+function choose(projection){
+    var polarval = false;
+    if (projection == "polar") {
+      polarval = true;
+    }
+
+    if (projection == "pyramid"){
+      createPyramid();
+    } else {
+      createChart(polarval);
+    }
+}
+
+function createChart(polarval) {
+  Highcharts.chart('container_bar', {
+      chart: {
+          type: 'bar',
+          polar: polarval,
+          height: 600
+      },
+      title: {
+          text: 'xMatch found with Simbad catalogs'
+      },
+      legend: {
+          enabled: false
+      },
+      subtitle: {
+          text: 'Refreshed every 10 seconds'
+      },
+      data: {
+          csvURL: window.location.origin + '/data/simbadtype.csv',
+          enablePolling: true,
+          dataRefreshRate: 10
+      },
+      plotOptions: {
+          series: {
+              zones: [{
+                  color: '#4CAF50',
+                  value: 0
+              }, {
+                  color: '#8BC34A',
+                  value: 10
+              }, {
+                  color: '#CDDC39',
+                  value: 20
+              }, {
+                  color: '#CDDC39',
+                  value: 30
+              }, {
+                  color: '#FFEB3B',
+                  value: 40
+              }, {
+                  color: '#FFEB3B',
+                  value: 50
+              }, {
+                  color: '#FFC107',
+                  value: 60
+              }, {
+                  color: '#FF9800',
+                  value: 70
+              }, {
+                  color: '#FF5722',
+                  value: 80
+              }, {
+                  color: '#F44336',
+                  value: 90
+              }, {
+                  color: '#F44336',
+                  value: Number.MAX_VALUE
+              }],
+              dataLabels: {
+                  enabled: true,
+                  format: '{point.y:.0f}'
+              }
+          }
+      },
+      tooltip: {
+          valueDecimals: 0,
+          valueSuffix: ''
+      },
+      xAxis: {
+          type: 'category',
+          labels: {
+              style: {
+                  fontSize: '10px'
+              }
+          }
+      },
+      yAxis: {
+          // max: dataMax,
+          type: 'logarithmic',
+          title: false,
+          plotBands: [{
+              from: 0,
+              to: 10,
+              color: '#E8F5E9'
+          }, {
+              from: 10,
+              to: 100,
+              color: '#FFFDE7'
+          }, {
+              from: 100,
+              to: 1000,
+              color: "#FFEBEE"
+          }, {
+              from: 1000,
+              to: 10000,
+              color: "#FFEBEE"
+          }]
+      }
+  });
+}
+
+function createPyramid() {
+  Highcharts.chart('container_bar', {
+      chart: {
+          type: 'pyramid',
+          height: 600
+      },
+      title: {
+          text: 'xMatch found with Simbad catalogs'
+      },
+      legend: {
+          enabled: false
+      },
+      subtitle: {
+          text: 'Refreshed every 10 seconds'
+      },
+      data: {
+          csvURL: window.location.origin + '/data/simbadtype.csv',
+          enablePolling: true,
+          dataRefreshRate: 30
+      },
+      yAxis: {
+          // max: dataMax,
+          type: 'logarithmic'
+      },
+      plotOptions: {
+        series: {
+            dataLabels: {
+                enabled: true,
+                format: '<b>{point.name}</b> ({point.y:,.0f})',
+                color: (Highcharts.theme && Highcharts.theme.contrastTextColor) || 'black',
+                softConnector: true
+            },
+            center: ['40%', '50%'],
+            width: '80%'
+        }
+    },
+  });
+}
+
+createChart(false);

--- a/web/live.html
+++ b/web/live.html
@@ -29,6 +29,7 @@
       <a href="/index.html">Fink</a>
       <a class="active" href="/live.html">Live</a>
       <a href="/history.html">History</a>
+      <a href="/classification.html">Classification</a>
       <a href="/skymap.html">Sky map</a>
       <a href="/about.html">About</a>
     </div>


### PR DESCRIPTION
Linked to issue(s): #185 

## What changes were proposed in this pull request?

This PR adds a new tab to the dashboard for monitoring simple early classification. The classification is done by cross-matching the alert stream with the catalogs at CDS Strasbourg (using the xmatch service).

## How was this patch tested?

Manually