### PR TITLE
Bump HBase version for the CI to 2.1.5

### DIFF
--- a/conf/install_hbase.sh
+++ b/conf/install_hbase.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 set -e
 
-HBASE_VERSION=2.1.4
+HBASE_VERSION=2.1.5
 
 wget http://www-us.apache.org/dist/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz
 tar -zxvf hbase-${HBASE_VERSION}-bin.tar.gz


### PR DESCRIPTION
Linked to issue(s): #187 

## What changes were proposed in this pull request?

This PR bumps the HBase version used for the CI tests to 2.1.5 (latest).

## How was this patch tested?

By running the CI with the new HBase version, and observing no failures.