### PR TITLE
Add the path to the HBase configuration file when running raw2science

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -200,7 +200,15 @@ elif [[ $service == "stream2raw" ]]; then
     -finkwebpath ${FINK_UI_PATH} -tinterval ${FINK_TRIGGER_UPDATE} \
     ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "raw2science" ]]; then
-  export SPARK_CLASSPATH=${HBASE_XML_CONF}
+
+  # For use on cluster, the HBase configuration file is actually mandatory.
+  if [[ -f ${HBASE_XML_CONF} ]]; then
+    export SPARK_CLASSPATH=${HBASE_XML_CONF}
+  else
+    echo "[WARN] HBase configuration file cannot be found at" ${HBASE_XML_CONF}
+    HBASE_XML_CONF=
+  fi
+
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \

--- a/bin/fink
+++ b/bin/fink
@@ -206,7 +206,8 @@ elif [[ $service == "raw2science" ]]; then
     export SPARK_CLASSPATH=${HBASE_XML_CONF}
   else
     echo "[WARN] HBase configuration file cannot be found at" ${HBASE_XML_CONF}
-    HBASE_XML_CONF=
+    echo "[WARN] Default HBase file will be used " ${FINK_HOME}/conf/hbase-site.xml
+    HBASE_XML_CONF=${FINK_HOME}/conf/hbase-site.xml
   fi
 
   # Store the stream of alerts

--- a/bin/fink
+++ b/bin/fink
@@ -200,11 +200,13 @@ elif [[ $service == "stream2raw" ]]; then
     -finkwebpath ${FINK_UI_PATH} -tinterval ${FINK_TRIGGER_UPDATE} \
     ${EXIT_AFTER} ${HELP_ON_SERVICE}
 elif [[ $service == "raw2science" ]]; then
+  export SPARK_CLASSPATH=${HBASE_XML_CONF}
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     --jars ${FINK_JARS} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
+    --files ${HBASE_XML_CONF} \
     ${FINK_HOME}/bin/raw2science.py -rawdatapath ${FINK_ALERT_PATH} \
     -checkpointpath_sci ${FINK_ALERT_CHECKPOINT_SCI} \
     -science_db_name ${SCIENCE_DB_NAME} \

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -73,6 +73,10 @@ FINK_ALERT_CHECKPOINT_SCI=${FINK_HOME}/archive/alerts_sci_checkpoint
 SCIENCE_DB_NAME="test_catalog"
 SCIENCE_DB_CATALOG=${FINK_HOME}/catalog.json
 
+# HBase configuration file - must be under ${SPARK_HOME}/conf
+# You can find an example in ${FINK_HOME}/conf
+HBASE_XML_CONF=${SPARK_HOME}/conf/hbase-site.xml
+
 ######################################
 # Dashboard
 # Where the web data will be posted and retrieved by the UI.

--- a/conf/fink.conf.cluster
+++ b/conf/fink.conf.cluster
@@ -73,6 +73,10 @@ FINK_ALERT_CHECKPOINT_SCI=""
 SCIENCE_DB_NAME=""
 SCIENCE_DB_CATALOG=${FINK_HOME}/catalog.json
 
+# HBase configuration file - must be under ${SPARK_HOME}/conf
+# You can find an example in ${FINK_HOME}/conf
+HBASE_XML_CONF=${SPARK_HOME}/conf/hbase-site.xml
+
 ######################################
 # Dashboard
 # Where the web data will be posted and retrieved by the UI.

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -73,6 +73,10 @@ FINK_ALERT_CHECKPOINT_SCI=${FINK_HOME}/archive/alerts_sci_checkpoint
 SCIENCE_DB_NAME="test_travis"
 SCIENCE_DB_CATALOG=${FINK_HOME}/catalog.json
 
+# HBase configuration file - must be under ${SPARK_HOME}/conf
+# You can find an example in ${FINK_HOME}/conf
+HBASE_XML_CONF=${SPARK_HOME}/conf/hbase-site.xml
+
 ######################################
 # Dashboard
 # Where the web data will be posted and retrieved by the UI.

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -103,6 +103,15 @@ Do not forget to give a name to your HBase science table:
 SCIENCE_DB_NAME="test_catalog"
 ```
 
+And link to the HBase XML configuration file of your cluster. The file must be
+located in the `conf` folder of the Spark installation:
+
+```
+# HBase configuration file - must be under ${SPARK_HOME}/conf
+# You can find an example in ${FINK_HOME}/conf
+HBASE_XML_CONF=${SPARK_HOME}/conf/hbase-site.xml
+```
+
 ## Configuring the dashboard
 
 Where the web data will be posted and retrieved by the dashboard.


### PR DESCRIPTION
Linked to issue(s): #194 

## What changes were proposed in this pull request?

This PR adds a new entry in the configuration file to specify the path to the HBase configuration file. This is required when working on a cluster, and the file must located in the Spark installation folder (in the `conf` directory) to ease the use.

## How was this patch tested?

Manually on a cluster.