### PR TITLE
Update gitignore with mgmt files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ datasim/*.avro
 target/
 archive/
 web/data/
+catalog.json
+distribution.offset


### PR DESCRIPTION
Linked to issue(s): #208 

## What changes were proposed in this pull request?

This PR updates `.gitignore` to discard `catalog.json` and `distribution.offset`

## How was this patch tested?

Manually