### PR TITLE
Catch TimeoutError and ConnectionError when doing xmatch with CDS

### DIFF
--- a/fink_broker/classification.py
+++ b/fink_broker/classification.py
@@ -190,7 +190,7 @@ def cross_match_alerts_raw(oid: list, ra: list, dec: list) -> list:
             # Mark as unknown if no match
             out.append((id_in, ra_in, dec_in, "Unknown", "Unknown"))
 
-        return out
+    return out
 
 
 if __name__ == "__main__":

--- a/userfilters/levelone.py
+++ b/userfilters/levelone.py
@@ -104,6 +104,11 @@ def cross_match_alerts_per_batch(objectId: Any, ra: Any, dec: Any) -> pd.Series:
 
     """
     matches = cross_match_alerts_raw(objectId.values, ra.values, dec.values)
+
+    # For regular alerts, the number of matches is always non-zero as
+    # alerts with no counterpart will be labeled as Unknown.
+    # If cross_match_alerts_raw returns a zero-length list of matches, it is
+    # a sign of a problem (logged).
     if len(matches) > 0:
         # (objectId, ra, dec, name, type)
         # return only the type.


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #220 

## What changes were proposed in this pull request?

This PR introduces better control of errors when performing xmatch with the data host at CDS. The xmatch returns 3 different options now:

- simbad ID if a match was found
- `Unknown` string if no match was found
- `Fail` string if connection errors happen (`TimeoutError` or `ConnectionError`).

## How was this patch tested?

Manually