### PR TITLE
New service: Fink shell

### DIFF
--- a/bin/fink_shell
+++ b/bin/fink_shell
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Copyright 2019 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+message_help="""
+Launch pyspark shell with Fink configuration pre-loaded \n\n
+Usage:\n
+  \tfink_shell [option] \n\n
+Option:\n
+  \t-c <CONFIGURATION_FILE>\n
+    \t\tSpecify a configuration file. Default is conf/fink.conf.shell \n\n
+  \t-h, --help \n
+    \t\tTo view this help message \n\n
+"""
+
+# Grab the command line arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h)
+        echo -e $message_help
+        exit
+        ;;
+    -c)
+        if [[ $2 == "" ]]; then
+          echo "$1 requires an argument" >&2
+          exit 1
+        fi
+        conf="$2"
+        shift 2
+        ;;
+  esac
+done
+
+# Source configuration file for tests
+if [[ -f $conf ]]; then
+  echo "Reading custom shell configuration file from " $conf
+else
+  conf=${FINK_HOME}/conf/fink.conf.shell
+  echo "Reading the default shell configuration file from " $conf
+fi
+
+source $conf
+
+export PYSPARK_DRIVER_PYTHON=$PYSPARK_DRIVER_PYTHON
+export FINK_PACKAGES=$FINK_PACKAGES
+export FINK_JARS=$FINK_JARS
+export SPARK_MASTER=$SPARK_MASTER
+export EXTRA_SPARK_CONFIG=$EXTRA_SPARK_CONFIG
+export HBASE_XML_CONF=$HBASE_XML_CONF
+
+# For use on cluster, the HBase configuration file is actually mandatory.
+if [[ -f ${HBASE_XML_CONF} ]]; then
+  export SPARK_CLASSPATH=${HBASE_XML_CONF}
+else
+  echo "[WARN] HBase configuration file cannot be found at" ${HBASE_XML_CONF}
+  echo "[WARN] Default HBase file will be used " ${FINK_HOME}/conf/hbase-site.xml
+  HBASE_XML_CONF=${FINK_HOME}/conf/hbase-site.xml
+fi
+
+PYSPARK_DRIVER_PYTHON=${PYSPARK_DRIVER_PYTHON} pyspark \
+  --master ${SPARK_MASTER} ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
+  --files ${HBASE_XML_CONF} \
+  --jars ${FINK_JARS} --packages ${FINK_PACKAGES}
+
+unset PYSPARK_DRIVER_PYTHON
+unset FINK_PACKAGES
+unset FINK_JARS
+unset SPARK_MASTER
+unset EXTRA_SPARK_CONFIG
+unset HBASE_XML_CONF

--- a/bin/fink_shell
+++ b/bin/fink_shell
@@ -60,6 +60,7 @@ export FINK_JARS=$FINK_JARS
 export SPARK_MASTER=$SPARK_MASTER
 export EXTRA_SPARK_CONFIG=$EXTRA_SPARK_CONFIG
 export HBASE_XML_CONF=$HBASE_XML_CONF
+export DEPLOY_FINK_PYTHON=$DEPLOY_FINK_PYTHON
 
 # For use on cluster, the HBase configuration file is actually mandatory.
 if [[ -f ${HBASE_XML_CONF} ]]; then
@@ -70,9 +71,21 @@ else
   HBASE_XML_CONF=${FINK_HOME}/conf/hbase-site.xml
 fi
 
+# For use on cluster, we need to package fink_broker
+PYTHON_EXTRA_FILE=""
+if [[ $DEPLOY_FINK_PYTHON != "false" ]]; then
+  cd $FINK_HOME
+  python3 setup.py bdist_egg
+  FINK_VERSION=`fink --version`
+  PYTHON_VERSION=`python -c "import platform; print(platform.python_version()[:3])"`
+  PYTHON_EXTRA_FILE="--py-files ${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
+  echo "Distributing ${PYTHON_EXTRA_FILE}"
+  cd -
+fi
+
 PYSPARK_DRIVER_PYTHON=${PYSPARK_DRIVER_PYTHON} pyspark \
   --master ${SPARK_MASTER} ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
-  --files ${HBASE_XML_CONF} \
+  --files ${HBASE_XML_CONF} ${PYTHON_EXTRA_FILE} \
   --jars ${FINK_JARS} --packages ${FINK_PACKAGES}
 
 unset PYSPARK_DRIVER_PYTHON
@@ -81,3 +94,4 @@ unset FINK_JARS
 unset SPARK_MASTER
 unset EXTRA_SPARK_CONFIG
 unset HBASE_XML_CONF
+unset DEPLOY_FINK_PYTHON

--- a/bin/fink_shell
+++ b/bin/fink_shell
@@ -61,6 +61,11 @@ export SPARK_MASTER=$SPARK_MASTER
 export EXTRA_SPARK_CONFIG=$EXTRA_SPARK_CONFIG
 export HBASE_XML_CONF=$HBASE_XML_CONF
 export DEPLOY_FINK_PYTHON=$DEPLOY_FINK_PYTHON
+export DEPLOY_FINK_SCALA=$DEPLOY_FINK_SCALA
+
+# Grab Fink and Python version numbers
+FINK_VERSION=`fink --version`
+PYTHON_VERSION=`python -c "import platform; print(platform.python_version()[:3])"`
 
 # For use on cluster, the HBase configuration file is actually mandatory.
 if [[ -f ${HBASE_XML_CONF} ]]; then
@@ -76,17 +81,27 @@ PYTHON_EXTRA_FILE=""
 if [[ $DEPLOY_FINK_PYTHON != "false" ]]; then
   cd $FINK_HOME
   python3 setup.py bdist_egg
-  FINK_VERSION=`fink --version`
-  PYTHON_VERSION=`python -c "import platform; print(platform.python_version()[:3])"`
   PYTHON_EXTRA_FILE="--py-files ${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
   echo "Distributing ${PYTHON_EXTRA_FILE}"
+  cd -
+fi
+
+# Default is to use fink jars distributed with the code
+FINK_EXTRA_JARS=${FINK_JARS},${FINK_HOME}/libs/fink-broker_2.11-${FINK_VERSION}.jar
+
+# Otherwise compile Scala source and ship it.
+if [[ $DEPLOY_FINK_SCALA != "false" ]]; then
+  cd $FINK_HOME
+  sbt ++2.11.8 package
+  FINK_EXTRA_JARS=${FINK_JARS},${FINK_HOME}/target/scala-2.11/fink-broker_2.11-${FINK_VERSION}.jar
+  echo "Distributing ${FINK_EXTRA_JARS}"
   cd -
 fi
 
 PYSPARK_DRIVER_PYTHON=${PYSPARK_DRIVER_PYTHON} pyspark \
   --master ${SPARK_MASTER} ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
   --files ${HBASE_XML_CONF} ${PYTHON_EXTRA_FILE} \
-  --jars ${FINK_JARS} --packages ${FINK_PACKAGES}
+  --jars ${FINK_EXTRA_JARS} --packages ${FINK_PACKAGES}
 
 unset PYSPARK_DRIVER_PYTHON
 unset FINK_PACKAGES
@@ -95,3 +110,4 @@ unset SPARK_MASTER
 unset EXTRA_SPARK_CONFIG
 unset HBASE_XML_CONF
 unset DEPLOY_FINK_PYTHON
+unset DEPLOY_FINK_SCALA

--- a/conf/fink.conf.shell
+++ b/conf/fink.conf.shell
@@ -48,9 +48,8 @@ org.apache.hbase:hbase-client:2.1.4,\
 org.apache.hbase:hbase-common:2.1.4,\
 org.apache.hbase:hbase-mapreduce:2.1.4
 
-# Other dependencies (incl. Scala part of Fink)
-FINK_JARS=${FINK_HOME}/libs/fink-broker_2.11-0.2.0.jar,\
-${FINK_HOME}/libs/shc-core-1.1.3-2.4-s_2.11.jar
+# Other dependencies (NOT incl. Scala part of Fink)
+FINK_JARS=${FINK_HOME}/libs/shc-core-1.1.3-2.4-s_2.11.jar
 
 # HBase configuration file - must be under ${SPARK_HOME}/conf
 # You can find an example in ${FINK_HOME}/conf

--- a/conf/fink.conf.shell
+++ b/conf/fink.conf.shell
@@ -1,0 +1,49 @@
+# Copyright 2019 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######################################
+# Pyspark driver: None, Ipython, or Jupyter-notebook
+# Note: for Jupyter on a cluster, you might need to specify the options
+# --no-browser --port=<PORT>, and perform port redirection when ssh-ing.
+PYSPARK_DRIVER_PYTHON=`which ipython`
+# PYSPARK_DRIVER_PYTHON=`which jupyter-notebook`
+
+# Apache Spark mode
+SPARK_MASTER="local[*]"
+
+# Should be Spark options actually (cluster resources, ...)
+EXTRA_SPARK_CONFIG=""
+# EXTRA_SPARK_CONFIG="--driver-memory 4g --executor-memory 30g --executor-cores 17 --total-executor-cores 51"
+
+# Should be Kafka secured options actually (to allow connection to Kafka)
+SECURED_KAFKA_CONFIG=''
+
+# These are the Maven Coordinates of dependencies for Fink
+# Change the version according to your Spark version.
+# NOTE: HBase packages are not required for Parquet archiving
+FINK_PACKAGES=\
+org.apache.spark:spark-streaming-kafka-0-10-assembly_2.11:2.4.1,\
+org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.1,\
+org.apache.spark:spark-avro_2.11:2.4.1,\
+org.apache.hbase:hbase-client:2.1.4,\
+org.apache.hbase:hbase-common:2.1.4,\
+org.apache.hbase:hbase-mapreduce:2.1.4
+
+# Other dependencies (incl. Scala part of Fink)
+FINK_JARS=${FINK_HOME}/libs/fink-broker_2.11-0.2.0.jar,\
+${FINK_HOME}/libs/shc-core-1.1.3-2.4-s_2.11.jar
+
+# HBase configuration file - must be under ${SPARK_HOME}/conf
+# You can find an example in ${FINK_HOME}/conf
+HBASE_XML_CONF=${SPARK_HOME}/conf/hbase-site.xml

--- a/conf/fink.conf.shell
+++ b/conf/fink.conf.shell
@@ -29,6 +29,14 @@ EXTRA_SPARK_CONFIG=""
 # Should be Kafka secured options actually (to allow connection to Kafka)
 SECURED_KAFKA_CONFIG=''
 
+# If set to false, it will assume the fink_broker is in your PYTHONPATH
+# otherwise it will package it, and send it to the executors.
+DEPLOY_FINK_PYTHON=false
+
+# If set to false, it will take the fink jars under $FINK_HOME/libs
+# otherwise the Scala sources will be recompiled and send to executors.
+DEPLOY_FINK_SCALA=false
+
 # These are the Maven Coordinates of dependencies for Fink
 # Change the version according to your Spark version.
 # NOTE: HBase packages are not required for Parquet archiving


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #217 

## What changes were proposed in this pull request?

This PR introduces the `fink_shell` which allows launching a pyspark shell with Fink configuration pre-loaded. Users can choose the driver (ipython or jupyter) and the size of the cluster. Usage is simply:

```
Launch pyspark shell with Fink configuration pre-loaded

 Usage:
 	fink_shell [option]

 Option:
 	-c <CONFIGURATION_FILE>
 		Specify a configuration file. Default is conf/fink.conf.shell

 	-h, --help
 		To view this help message
```

Todo:
- [x] For cluster usage, package fink_broker and send it to executors.
- [x] For all usage, compile Scala source and include it in the FINK_JARS (add default with the one under `libs/`).

## How was this patch tested?

Manually