### PR TITLE
Move helper first in the argument list for services

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -201,28 +201,27 @@ elif [[ $service == "simulator" ]]; then
     echo "docker-compose not found"
     exit
   fi
-  python3 ${FINK_HOME}/bin/simulate_stream.py \
+  python3 ${FINK_HOME}/bin/simulate_stream.py ${HELP_ON_SERVICE} \
     -servers ${KAFKA_IPPORT_SIM} -topic ${KAFKA_TOPIC_SIM} -datasimpath ${FINK_DATA_SIM}\
-    -tinterval_kafka ${TIME_INTERVAL} -poolsize ${POOLSIZE} ${HELP_ON_SERVICE}
+    -tinterval_kafka ${TIME_INTERVAL} -poolsize ${POOLSIZE}
 elif [[ $service == "checkstream" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
-    ${FINK_HOME}/bin/checkstream.py -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
-    -startingoffsets_stream ${KAFKA_STARTING_OFFSET} -finkwebpath ${FINK_UI_PATH} \
-    ${EXIT_AFTER} ${HELP_ON_SERVICE}
+    ${FINK_HOME}/bin/checkstream.py ${HELP_ON_SERVICE} -servers ${KAFKA_IPPORT} \
+    -topic ${KAFKA_TOPIC} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
+    -finkwebpath ${FINK_UI_PATH} ${EXIT_AFTER}
 elif [[ $service == "stream2raw" ]]; then
 
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
-    ${FINK_HOME}/bin/stream2raw.py -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
+    ${FINK_HOME}/bin/stream2raw.py ${HELP_ON_SERVICE} -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
     -schema ${FINK_ALERT_SCHEMA} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
     -rawdatapath ${FINK_ALERT_PATH} -checkpointpath_raw ${FINK_ALERT_CHECKPOINT_RAW} \
-    -finkwebpath ${FINK_UI_PATH} -tinterval ${FINK_TRIGGER_UPDATE} \
-    ${EXIT_AFTER} ${HELP_ON_SERVICE}
+    -finkwebpath ${FINK_UI_PATH} -tinterval ${FINK_TRIGGER_UPDATE} ${EXIT_AFTER}
 elif [[ $service == "raw2science" ]]; then
 
   # For use on cluster, the HBase configuration file is actually mandatory.
@@ -240,16 +239,18 @@ elif [[ $service == "raw2science" ]]; then
     --jars ${FINK_JARS} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     --files ${HBASE_XML_CONF} \
-    ${FINK_HOME}/bin/raw2science.py -rawdatapath ${FINK_ALERT_PATH} \
+    ${FINK_HOME}/bin/raw2science.py ${HELP_ON_SERVICE} \
+    -rawdatapath ${FINK_ALERT_PATH} \
     -checkpointpath_sci ${FINK_ALERT_CHECKPOINT_SCI} \
     -science_db_name ${SCIENCE_DB_NAME} \
-    -science_db_catalog ${SCIENCE_DB_CATALOG} ${EXIT_AFTER} ${HELP_ON_SERVICE}
+    -science_db_catalog ${SCIENCE_DB_CATALOG} ${EXIT_AFTER}
 elif [[ $service == "distribution" ]]; then
   # Start the Spark Producer
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
   --jars ${FINK_JARS} \
-  ${FINK_HOME}/bin/distribute.py -science_db_catalog ${SCIENCE_DB_CATALOG} \
+  ${FINK_HOME}/bin/distribute.py ${HELP_ON_SERVICE} \
+  -science_db_catalog ${SCIENCE_DB_CATALOG} \
   -science_db_name ${SCIENCE_DB_NAME} \
   -distribution_schema ${DISTRIBUTION_SCHEMA} \
   -startingOffset_dist ${DISTRIBUTION_OFFSET} \
@@ -260,7 +261,7 @@ elif [[ $service == "distribution_test" ]]; then
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
   --jars ${FINK_JARS} \
-  ${FINK_HOME}/bin/distribution_test.py ${EXIT_AFTER} \
+  ${FINK_HOME}/bin/distribution_test.py ${HELP_ON_SERVICE} ${EXIT_AFTER} \
   -distribution_schema ${DISTRIBUTION_SCHEMA}
 else
   # In case you give an unknown service


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #239 

## What changes were proposed in this pull request?

This PR moves helper first in the argument list for services to access the help before trying to populate input argument (that can be missing at first). This allows the service help to be printed correctly:

```bash
# Example
$ fink start stream2raw -h
usage: stream2raw.py [-h] [-servers SERVERS] [-topic TOPIC] [-schema SCHEMA]
                     [-startingoffsets_stream STARTINGOFFSETS_STREAM]
                     [-rawdatapath RAWDATAPATH]
                     [-checkpointpath_raw CHECKPOINTPATH_RAW]
                     [-checkpointpath_sci CHECKPOINTPATH_SCI]
                     [-science_db_name SCIENCE_DB_NAME]
                     [-science_db_catalog SCIENCE_DB_CATALOG]
                     [-finkwebpath FINKWEBPATH] [-tinterval TINTERVAL]
                     [-tinterval_kafka TINTERVAL_KAFKA]
                     [-exit_after EXIT_AFTER] [-datasimpath DATASIMPATH]
                     [-poolsize POOLSIZE]
                     [-distribution_schema DISTRIBUTION_SCHEMA]
                     [-startingOffset_dist STARTINGOFFSET_DIST]
                     [-checkpointpath_dist CHECKPOINTPATH_DIST]
                     [-distribution_rules_xml DISTRIBUTION_RULES_XML]

Store live stream data on disk. The output can be local FS or distributed FS
(e.g. HDFS). Be careful though to have enough disk space! For some output
sinks where the end-to-end fault-tolerance can be guaranteed, you will need to
specify the location where the system will write all the checkpoint
information. This should be a directory in an HDFS-compatible fault-tolerant
file system. See also https://spark.apache.org/docs/latest/ structured-
streaming-programming-guide.html#starting-streaming-queries

optional arguments:
  -h, --help            show this help message and exit
  -servers SERVERS      Hostname or IP and port of Kafka broker producing
                        stream. [KAFKA_IPPORT/KAFKA_IPPORT_SIM]
  -topic TOPIC          Name of Kafka topic stream to read from.
                        [KAFKA_TOPIC/KAFKA_TOPIC_SIM]
  -schema SCHEMA        Schema to decode the alert. Should be avro file.
                        [FINK_ALERT_SCHEMA]
  -startingoffsets_stream STARTINGOFFSETS_STREAM
                        From which stream offset you want to start pulling
                        data when building the raw database: latest, earliest,
                        or custom. [KAFKA_STARTING_OFFSET]
  -rawdatapath RAWDATAPATH
                        Directory on disk for saving raw alert data.
                        [FINK_ALERT_PATH]
  -checkpointpath_raw CHECKPOINTPATH_RAW
                        The location where the system will write all the
                        checkpoint information for the raw datable. This shoul
                        be a directory in an HDFS-compatible fault-tolerant
                        file system. See conf/fink.conf &
                        https://spark.apache.org/docs/latest/ structured-
                        streaming-programming-guide.html#starting-streaming-
                        queries [FINK_ALERT_CHECKPOINT_RAW]
  -checkpointpath_sci CHECKPOINTPATH_SCI
                        The location where the system will write all the
                        checkpoint information for the science datable. This
                        should be a directory in an HDFS-compatible fault-
                        tolerant file system. See conf/fink.conf &
                        https://spark.apache.org/docs/latest/ structured-
                        streaming-programming-guide.html#starting-streaming-
                        queries [FINK_ALERT_CHECKPOINT_SCI]
  -science_db_name SCIENCE_DB_NAME
                        The name of the HBase table [SCIENCE_DB_NAME]
  -science_db_catalog SCIENCE_DB_CATALOG
                        The path of HBase catalog [SCIENCE_DB_CATALOG]
  -finkwebpath FINKWEBPATH
                        Folder to store UI data for display. [FINK_UI_PATH]
  -tinterval TINTERVAL  Time interval between two monitoring. In seconds.
                        [FINK_TRIGGER_UPDATE]
  -tinterval_kafka TINTERVAL_KAFKA
                        Time interval between two messages are published. In
                        seconds. [TIME_INTERVAL]
  -exit_after EXIT_AFTER
                        Stop the service after `exit_after` seconds. This
                        primarily for use on Travis, to stop service after
                        some time. Use that with `fink start service
                        --exit_after <time>`. Default is None.
  -datasimpath DATASIMPATH
                        Folder containing simulated alerts to be published by
                        Kafka. [FINK_DATA_SIM]
  -poolsize POOLSIZE    Maximum number of alerts to send. If the poolsize is
                        bigger than the number of alerts in `datapath`, then
                        we replicate the alerts. Default is 5. [POOLSIZE]
  -distribution_schema DISTRIBUTION_SCHEMA
                        The path where the avro schema for alert distribution
                        is stored [DISTRIBUTION_SCHEMA]
  -startingOffset_dist STARTINGOFFSET_DIST
                        From which offset(timestamp) you want to start the
                        distribution service. Options are: latest, earliest or
                        a custom timestamp [DISTRIBUTION_OFFSET]
  -checkpointpath_dist CHECKPOINTPATH_DIST
                        The path of file in which to store the offset for
                        distribution service. This file will store the
                        timestamp up-till which the science db is scanned and
                        alerts have been distributed.
                        [DISTRIBUTION_OFFSET_FILE]
  -distribution_rules_xml DISTRIBUTION_RULES_XML
                        The path to distribution-rules.xml which stores user
                        defined rules to filter the distribution stream
                        [DISTRIBUTION_RULES_XML]
```
## How was this patch tested?

Manually