### PR TITLE
Ship fink_broker and usefilters modules when submitting Spark jobs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ data_file = ${PWD}/.coverage
 omit=
     $SPARK_HOME/*
     setup.py
+    dist/*

--- a/bin/fink
+++ b/bin/fink
@@ -285,6 +285,3 @@ else
   echo $message_service
   exit 1
 fi
-
-# Cleaning the egg
-rm ${PYTHON_EXTRA_FILE}

--- a/bin/fink
+++ b/bin/fink
@@ -179,6 +179,18 @@ fi
 
 # Start services
 mkdir -p ${FINK_HOME}/web/data
+
+# Grab Fink and Python version numbers
+FINK_VERSION=`fink --version`
+PYTHON_VERSION=`python -c "import platform; print(platform.python_version()[:3])"`
+
+# Package fink_broker & userfilters modules
+cd $FINK_HOME
+python3 setup.py bdist_egg
+PYTHON_EXTRA_FILE="--py-files ${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
+echo "Distributing ${PYTHON_EXTRA_FILE}"
+cd -
+
 if [[ $service == "dashboard" ]]; then
   # Launch the UI
   export is_docker=`command -v docker-compose`
@@ -207,7 +219,7 @@ elif [[ $service == "simulator" ]]; then
 elif [[ $service == "checkstream" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-    --packages ${FINK_PACKAGES} \
+    --packages ${FINK_PACKAGES} ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/checkstream.py ${HELP_ON_SERVICE} -servers ${KAFKA_IPPORT} \
     -topic ${KAFKA_TOPIC} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
@@ -216,7 +228,7 @@ elif [[ $service == "stream2raw" ]]; then
 
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-    --packages ${FINK_PACKAGES} \
+    --packages ${FINK_PACKAGES} ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/stream2raw.py ${HELP_ON_SERVICE} -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
     -schema ${FINK_ALERT_SCHEMA} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
@@ -237,6 +249,7 @@ elif [[ $service == "raw2science" ]]; then
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     --jars ${FINK_JARS} \
+    ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     --files ${HBASE_XML_CONF} \
     ${FINK_HOME}/bin/raw2science.py ${HELP_ON_SERVICE} \
@@ -250,6 +263,7 @@ elif [[ $service == "distribution" ]]; then
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
   --jars ${FINK_JARS} \
+  ${PYTHON_EXTRA_FILE} \
   ${FINK_HOME}/bin/distribute.py ${HELP_ON_SERVICE} \
   -science_db_catalog ${SCIENCE_DB_CATALOG} \
   -science_db_name ${SCIENCE_DB_NAME} \
@@ -262,7 +276,7 @@ elif [[ $service == "distribution_test" ]]; then
   # Start a spark consumer to test the distribution
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
-  --jars ${FINK_JARS} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} \
   ${FINK_HOME}/bin/distribution_test.py ${HELP_ON_SERVICE} ${EXIT_AFTER} \
   -distribution_schema ${DISTRIBUTION_SCHEMA} -log_level ${LOG_LEVEL}
 else

--- a/bin/fink
+++ b/bin/fink
@@ -189,7 +189,7 @@ PYTHON_EXTRA_FILE=""
 if [[ $DEPLOY_FINK_PYTHON == "true" ]]; then
   cd $FINK_HOME
   python3 setup.py bdist_egg
-  PYTHON_EXTRA_FILE="${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
+  PYTHON_EXTRA_FILE="--py-files ${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
   echo "Distributing ${PYTHON_EXTRA_FILE}"
   cd -
 fi
@@ -222,7 +222,7 @@ elif [[ $service == "simulator" ]]; then
 elif [[ $service == "checkstream" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-    --packages ${FINK_PACKAGES} --py-files ${PYTHON_EXTRA_FILE} \
+    --packages ${FINK_PACKAGES} ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/checkstream.py ${HELP_ON_SERVICE} -servers ${KAFKA_IPPORT} \
     -topic ${KAFKA_TOPIC} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
@@ -231,7 +231,7 @@ elif [[ $service == "stream2raw" ]]; then
 
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-    --packages ${FINK_PACKAGES} --py-files ${PYTHON_EXTRA_FILE} \
+    --packages ${FINK_PACKAGES} ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/stream2raw.py ${HELP_ON_SERVICE} -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
     -schema ${FINK_ALERT_SCHEMA} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
@@ -252,7 +252,7 @@ elif [[ $service == "raw2science" ]]; then
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     --jars ${FINK_JARS} \
-    --py-files ${PYTHON_EXTRA_FILE} \
+    ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     --files ${HBASE_XML_CONF} \
     ${FINK_HOME}/bin/raw2science.py ${HELP_ON_SERVICE} \
@@ -266,7 +266,7 @@ elif [[ $service == "distribution" ]]; then
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
   --jars ${FINK_JARS} \
-  --py-files ${PYTHON_EXTRA_FILE} \
+  ${PYTHON_EXTRA_FILE} \
   ${FINK_HOME}/bin/distribute.py ${HELP_ON_SERVICE} \
   -science_db_catalog ${SCIENCE_DB_CATALOG} \
   -science_db_name ${SCIENCE_DB_NAME} \
@@ -279,7 +279,7 @@ elif [[ $service == "distribution_test" ]]; then
   # Start a spark consumer to test the distribution
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
-  --jars ${FINK_JARS} --py-files ${PYTHON_EXTRA_FILE} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} \
   ${FINK_HOME}/bin/distribution_test.py ${HELP_ON_SERVICE} ${EXIT_AFTER} \
   -distribution_schema ${DISTRIBUTION_SCHEMA} -log_level ${LOG_LEVEL}
 else

--- a/bin/fink
+++ b/bin/fink
@@ -187,7 +187,7 @@ PYTHON_VERSION=`python -c "import platform; print(platform.python_version()[:3])
 # Package fink_broker & userfilters modules
 cd $FINK_HOME
 python3 setup.py bdist_egg
-PYTHON_EXTRA_FILE="--py-files ${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
+PYTHON_EXTRA_FILE="${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
 echo "Distributing ${PYTHON_EXTRA_FILE}"
 cd -
 
@@ -219,7 +219,7 @@ elif [[ $service == "simulator" ]]; then
 elif [[ $service == "checkstream" ]]; then
   # Monitor the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-    --packages ${FINK_PACKAGES} ${PYTHON_EXTRA_FILE} \
+    --packages ${FINK_PACKAGES} --py-files ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/checkstream.py ${HELP_ON_SERVICE} -servers ${KAFKA_IPPORT} \
     -topic ${KAFKA_TOPIC} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
@@ -228,7 +228,7 @@ elif [[ $service == "stream2raw" ]]; then
 
   # Store the stream of alerts
   spark-submit --master ${SPARK_MASTER} \
-    --packages ${FINK_PACKAGES} ${PYTHON_EXTRA_FILE} \
+    --packages ${FINK_PACKAGES} --py-files ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/stream2raw.py ${HELP_ON_SERVICE} -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
     -schema ${FINK_ALERT_SCHEMA} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
@@ -249,7 +249,7 @@ elif [[ $service == "raw2science" ]]; then
   spark-submit --master ${SPARK_MASTER} \
     --packages ${FINK_PACKAGES} \
     --jars ${FINK_JARS} \
-    ${PYTHON_EXTRA_FILE} \
+    --py-files ${PYTHON_EXTRA_FILE} \
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     --files ${HBASE_XML_CONF} \
     ${FINK_HOME}/bin/raw2science.py ${HELP_ON_SERVICE} \
@@ -263,7 +263,7 @@ elif [[ $service == "distribution" ]]; then
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
   --jars ${FINK_JARS} \
-  ${PYTHON_EXTRA_FILE} \
+  --py-files ${PYTHON_EXTRA_FILE} \
   ${FINK_HOME}/bin/distribute.py ${HELP_ON_SERVICE} \
   -science_db_catalog ${SCIENCE_DB_CATALOG} \
   -science_db_name ${SCIENCE_DB_NAME} \
@@ -276,7 +276,7 @@ elif [[ $service == "distribution_test" ]]; then
   # Start a spark consumer to test the distribution
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
-  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} \
+  --jars ${FINK_JARS} --py-files ${PYTHON_EXTRA_FILE} \
   ${FINK_HOME}/bin/distribution_test.py ${HELP_ON_SERVICE} ${EXIT_AFTER} \
   -distribution_schema ${DISTRIBUTION_SCHEMA} -log_level ${LOG_LEVEL}
 else
@@ -285,3 +285,6 @@ else
   echo $message_service
   exit 1
 fi
+
+# Cleaning the egg
+rm ${PYTHON_EXTRA_FILE}

--- a/bin/fink
+++ b/bin/fink
@@ -185,11 +185,14 @@ FINK_VERSION=`fink --version`
 PYTHON_VERSION=`python -c "import platform; print(platform.python_version()[:3])"`
 
 # Package fink_broker & userfilters modules
-cd $FINK_HOME
-python3 setup.py bdist_egg
-PYTHON_EXTRA_FILE="${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
-echo "Distributing ${PYTHON_EXTRA_FILE}"
-cd -
+PYTHON_EXTRA_FILE=""
+if [[ $DEPLOY_FINK_PYTHON == "true" ]]; then
+  cd $FINK_HOME
+  python3 setup.py bdist_egg
+  PYTHON_EXTRA_FILE="${FINK_HOME}/dist/fink_broker-${FINK_VERSION}-py${PYTHON_VERSION}.egg"
+  echo "Distributing ${PYTHON_EXTRA_FILE}"
+  cd -
+fi
 
 if [[ $service == "dashboard" ]]; then
   # Launch the UI

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -81,6 +81,10 @@ HBASE_XML_CONF=${SPARK_HOME}/conf/hbase-site.xml
 # Note that for Spark, the level is set to WARN (see log4j.properties)
 LOG_LEVEL=INFO
 
+# If set to false, it will assume the fink_broker is in your PYTHONPATH
+# otherwise it will package it, and send it to the executors.
+DEPLOY_FINK_PYTHON=true
+
 ######################################
 # Dashboard
 # Where the web data will be posted and retrieved by the UI.

--- a/conf/fink.conf.cluster
+++ b/conf/fink.conf.cluster
@@ -81,6 +81,10 @@ HBASE_XML_CONF=${SPARK_HOME}/conf/hbase-site.xml
 # Note that for Spark, the level is set to WARN (see log4j.properties)
 LOG_LEVEL=INFO
 
+# If set to false, it will assume the fink_broker is in your PYTHONPATH
+# otherwise it will package it, and send it to the executors.
+DEPLOY_FINK_PYTHON=true
+
 ######################################
 # Dashboard
 # Where the web data will be posted and retrieved by the UI.

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -81,6 +81,10 @@ HBASE_XML_CONF=${SPARK_HOME}/conf/hbase-site.xml
 # Note that for Spark, the level is set to WARN (see log4j.properties)
 LOG_LEVEL=INFO
 
+# If set to false, it will assume the fink_broker is in your PYTHONPATH
+# otherwise it will package it, and send it to the executors.
+DEPLOY_FINK_PYTHON=false
+
 ######################################
 # Dashboard
 # Where the web data will be posted and retrieved by the UI.


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #244 
## What changes were proposed in this pull request?

This PR modifies `bin/fink` to create an egg file with `fink_broker` and `userfilters` modules and shipping it to executors when submitting Spark jobs. That way, fink-broker does not need to be installed on executors.

## How was this patch tested?

Manually