### PR TITLE
Switch to TRAVIS_REPO_SLUG to allow for pr and push builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 
   # Scan with sonarqube only if internal PR (i.e. no fork)
   # Note: this is unsatisfactory...
-  - if [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-broker" ]; then
+  - if [ $TRAVIS_REPO_SLUG == "astrolabsoftware/fink-broker" ]; then
     coverage xml -i;
     sonar-scanner;
     fi


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #251 

## What changes were proposed in this pull request?

This PR uses `TRAVIS_REPO_SLUG` instead of `TRAVIS_PULL_REQUEST_SLUG` in the travis script to make sure both pr and push builds report to sonar.

## How was this patch tested?

Manually.