### PR TITLE
Fix wrong fix introduced in PR 252 on when using sonar in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 
   # Scan with sonarqube only if internal PR (i.e. no fork)
   # Note: this is unsatisfactory...
-  - if [ $TRAVIS_REPO_SLUG == "astrolabsoftware/fink-broker" ]; then
+  - if [ $TRAVIS_PULL_REQUEST == false ] || [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-broker"]; then
     coverage xml -i;
     sonar-scanner;
     fi


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #251 

## What changes were proposed in this pull request?

PR #252 introduced a wrong fix: all builds and PRs were trying to use sonar, while we only want all builds (from upstream) and only PRs originated from upstream.

## How was this patch tested?

Manually
