### PR TITLE
Fix TypeError in xmatch_slow

### DIFF
--- a/fink_broker/classification.py
+++ b/fink_broker/classification.py
@@ -153,7 +153,7 @@ def xmatch_slow(
 
     # create a mask with the entries of the query
     nans = [np.nan] * len(ra)
-    mask = pd.DataFrame(zip(nans, ra, dec, nans, id))
+    mask = pd.DataFrame(list(zip(nans, ra, dec, nans, id)))
     mask.columns = list_old_keys + ['objectId']
 
     # Send requests in vector form and obtain a table as a result


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #267 

## What changes were proposed in this pull request?
The following example leads to a TypeError:
https://github.com/astrolabsoftware/fink-broker/blob/a3efb02e6ec3a0a67666b8379e9342947e54080f/fink_broker/classification.py#L350

which is caused in `xmatch_slow`:
https://github.com/astrolabsoftware/fink-broker/blob/a3efb02e6ec3a0a67666b8379e9342947e54080f/fink_broker/classification.py#L156

This is caused as a result of passing `<zip>` to `pd.DataFrame()`
This can be fixed by passing a list instead. i.e:
```
mask = pd.DataFrame(list(zip(nans, ra, dec, nans, id)))
```