### PR TITLE
Issues/270/slack

### DIFF
--- a/fink_broker/slackUtils.py
+++ b/fink_broker/slackUtils.py
@@ -56,17 +56,15 @@ class FinkSlackClient:
         if recipient[0] == '#':
             name = recipient[1:]
             if name not in self._channel_ids:
-                logger.error("Invalid Channel Name")
-                return
-            channel_id = self._channel_ids[name]
+                logger.warn("Private or Invalid Channel Name")
         else:   # user
+            name = recipient
             if recipient not in self._user_ids:
                 logger.error("User is not member of your slack workspace")
                 return
-            channel_id = self._user_ids[recipient]
 
-        response = self._client.chat_postMessage(
-            channel=channel_id, text=msg, as_user="false",
+        self._client.chat_postMessage(
+            channel=name, text=msg, as_user="false",
             username="fink-alert", icon_emoji="strend:")
 
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.projectVersion=1.0
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 # This property is optional if sonar.modules is set.
 sonar.sources=fink_broker/,bin/
-sonar.exclusions=fink_broker/htmlcov
+sonar.exclusions=fink_broker/htmlcov,fink_broker/slackUtils.py
 
 # Path to coverage file (need xml)
 # run `coverage xml -i` after your test suite + coverage,


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #270, #271 

## What changes were proposed in this pull request?

This PR allows the broker to post message in Slack using the channel name instead of the channel ID. This allows to target both public and private channels (we cannot see the ID of private channels from the Slack client API).

Quick fix: disable sonar checks on `slackUtils.py`

## How was this patch tested?

Manually