### PR TITLE
Fix uncaught conditional in CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 
   # Scan with sonarqube only if internal PR (i.e. no fork)
   # Note: this is unsatisfactory...
-  - if [ $TRAVIS_PULL_REQUEST == false ] || [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-broker"]; then
+  - if [ $TRAVIS_PULL_REQUEST == true ] || [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-broker" ]; then
     coverage xml -i;
     sonar-scanner;
     fi


### PR DESCRIPTION
A forked build failed with this error:

    ERROR: Error during SonarQube Scanner execution
    ERROR: Not authorized. Please check the properties sonar.login and sonar.password.

    The command "if [ $TRAVIS_PULL_REQUEST == false ] || [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-client"]; then coverage xml -i; sonar-scanner; fi" exited with 1.

The conditional should have caught that the tests was not a
TRAVIS_PULL_REQUEST or the TRAVIS_PULL_REQUEST_SLUG was not
astrolabsoftware/fink_client but was a fork repo instead

REF:
    https://travis-ci.com/tallamjr/fink-broker/jobs/238121081

	modified:   .travis.yml

**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #273 

## What changes were proposed in this pull request?

By setting the logic to 'true' then sonar should only run when it is
a PR or when it is _not_ a forked repo.

## How was this patch tested?

Travis --> https://travis-ci.com/tallamjr/fink-broker/builds/128735120