### PR TITLE
Force to use pyarrow 0.14.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ confluent-kafka>=0.11.4
 avro-python3
 Cython
 fastavro
-pyarrow
+pyarrow==0.14.1
 codecov
 slackclient
 astropy


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #284 

## What changes were proposed in this pull request?

This PR forces the use of pyarrow 0.14.1 instead of the newly released 0.15.0 that introduced incompatibilities. Once a pyarrow patch will be released (or if we understand better the root of the problem on our side), we will remove the requirement.

## How was this patch tested?

CI