### PR TITLE
Use TRAVIS_REPO_SLUG to trigger sonar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
 
   # Scan with sonarqube only if internal PR (i.e. no fork)
   # Note: this is unsatisfactory...
-  - if [ $TRAVIS_PULL_REQUEST == true ] || [ $TRAVIS_PULL_REQUEST_SLUG == "astrolabsoftware/fink-broker" ]; then
+  - if [ $TRAVIS_REPO_SLUG == "astrolabsoftware/fink-broker" ]; then
     coverage xml -i;
     sonar-scanner;
     fi


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #286 

## What changes were proposed in this pull request?

This PR uses `TRAVIS_REPO_SLUG` to trigger sonar, to skip builds in fork or external PRs.

## How was this patch tested?

Manually
 Manually