### PR TITLE
save_avro_schema: use schema_path instead of path_for_avro in condition

### DIFF
--- a/fink_broker/distributionUtils.py
+++ b/fink_broker/distributionUtils.py
@@ -150,7 +150,7 @@ def save_avro_schema(df: DataFrame, schema_path: str):
     else:
         msg = """
             {} already exists - cannot write the new schema
-        """.format(path_for_avro)
+        """.format(schema_path)
         print(msg)
 
 def decode_kafka_df(df_kafka: DataFrame, schema_path: str) -> DataFrame:


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #304 

## What changes were proposed in this pull request?

This PR fixes bug in save_avro_schema, where `schema_path` should be used instead of `path_for_avro` in the second part of the condition.

## How was this patch tested?

CI