### PR TITLE
Use env variable instead of harcoded topic name in fink_kafka

### DIFF
--- a/bin/fink_kafka
+++ b/bin/fink_kafka
@@ -301,7 +301,7 @@ if [[ $SERVICE == "START" ]]; then
 
   # Enable Authorization
   # For Fink producer
-  add_acl_producer "finkProducer" "127.0.0.1" "fink_outstream"
+  add_acl_producer "finkProducer" "127.0.0.1" $DISTRIBUTION_TOPIC
 
   # For Fink's test consumer
   ${KAFKA_HOME}/bin/kafka-acls.sh \
@@ -310,7 +310,7 @@ if [[ $SERVICE == "START" ]]; then
   --allow-principal User:finkConsumer \
   --allow-host 127.0.0.1 \
   --consumer \
-  --topic fink_outstream \
+  --topic $DISTRIBUTION_TOPIC \
   --group spark-kafka- \
   --resource-pattern-type prefixed
 

--- a/conf/fink.conf.distribution
+++ b/conf/fink.conf.distribution
@@ -54,7 +54,7 @@ kafka_broker_logs[1]="${FINK_HOME}/fink_kafka_logs/broker1"
 kafka_broker_logs[2]="${FINK_HOME}/fink_kafka_logs/broker2"
 
 # Kafka topic to publish on
-DISTRIBUTION_TOPIC="fink_outstream"
+DISTRIBUTION_TOPIC="rrlyr"
 
 # The path where to store the avro distribution schema
 DISTRIBUTION_SCHEMA=${FINK_HOME}/schemas/distribution_schema.avsc


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #306

## What changes were proposed in this pull request?

To initialise test producer and consumer in fink_kafka, we now use the env variable `$DISTRIBUTION_TOPIC` defined in the configuration file instead of the harcoded topic name.

## How was this patch tested?

Manually