### PR TITLE
Add SN classification based on Random Forest

### DIFF
--- a/conf/fink.conf.distribution
+++ b/conf/fink.conf.distribution
@@ -57,7 +57,7 @@ kafka_broker_logs[2]="${FINK_HOME}/fink_kafka_logs/broker2"
 DISTRIBUTION_TOPIC="rrlyr"
 
 # The path where to store the avro distribution schema
-DISTRIBUTION_SCHEMA=${FINK_HOME}/schemas/distribution_schema_0p1.avsc
+DISTRIBUTION_SCHEMA=${FINK_HOME}/schemas/distribution_schema_0p2.avsc
 
 # Offset for reading the science database
 DISTRIBUTION_OFFSET="latest"

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,4 +1,4 @@
-numpy>=1.14
+numpy>=1.16
 coverage>=4.2
 coveralls
 pandas
@@ -11,3 +11,5 @@ codecov
 slackclient
 astropy
 astroquery
+scipy
+sklearn

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -12,4 +12,4 @@ slackclient
 astropy
 astroquery
 scipy
-sklearn
+scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ astroquery
 fink_filters
 fink_science
 scipy
-sklearn
+scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.14
+numpy>=1.16
 coverage>=4.2
 coveralls
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ astropy
 astroquery
 fink_filters
 fink_science
+scipy
+sklearn

--- a/schemas/distribution_schema_0p2.avsc
+++ b/schemas/distribution_schema_0p2.avsc
@@ -1,0 +1,1262 @@
+{
+  "type": "record",
+  "name": "topLevelRecord",
+  "fields": [
+    {
+      "name": "timestamp",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "schemavsn",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "objectId",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "candid",
+      "type": [
+        "long",
+        "null"
+      ]
+    },
+    {
+      "name": "candidate",
+      "type": {
+        "type": "record",
+        "name": "candidate",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "jd",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "fid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "pid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "diffmaglim",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "pdiffimfilename",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "programpi",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "programid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "candid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "isdiffpos",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "tblid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "nid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rcid",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "field",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "xpos",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ypos",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ra",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "dec",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "magpsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmapsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "chipsf",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magap",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagap",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "chinr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sharpnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sky",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magdiff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "fwhm",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "classtar",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "mindtoedge",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magfromlim",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "seeratio",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "aimage",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "bimage",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "aimagerat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "bimagerat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "elong",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nneg",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "nbad",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rb",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssdistnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssmagnr",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssnamenr",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "sumrat",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magapbig",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sigmagapbig",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ranr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "decnr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr1",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ndethist",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "ncovhist",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "jdstarthist",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "jdendhist",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "scorr",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "tooflag",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps1",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps2",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr2",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "objectidps3",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "sgmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "srmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "simag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "szmag3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "sgscore3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "distpsnr3",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nmtchps",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rfid",
+            "type": [
+              "long",
+              "null"
+            ]
+          },
+          {
+            "name": "jdstartref",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "jdendref",
+            "type": [
+              "double",
+              "null"
+            ]
+          },
+          {
+            "name": "nframesref",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "rbversion",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "dsnrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "ssnrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "dsdiff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpsci",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpsciunc",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "magzpscirms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "nmatches",
+            "type": [
+              "int",
+              "null"
+            ]
+          },
+          {
+            "name": "clrcoeff",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrcounc",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "zpclrcov",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "zpmed",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrmed",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "clrrms",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "neargaia",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "neargaiabright",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "maggaia",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "maggaiabright",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "exptime",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "drb",
+            "type": [
+              "float",
+              "null"
+            ]
+          },
+          {
+            "name": "drbversion",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "prv_candidates",
+      "type": [
+        {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "prv_candidates",
+            "namespace": "topLevelRecord",
+            "fields": [
+              {
+                "name": "jd",
+                "type": "double"
+              },
+              {
+                "name": "fid",
+                "type": "int"
+              },
+              {
+                "name": "pid",
+                "type": "long"
+              },
+              {
+                "name": "diffmaglim",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "pdiffimfilename",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "name": "programpi",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "name": "programid",
+                "type": "int"
+              },
+              {
+                "name": "candid",
+                "type": [
+                  "long",
+                  "null"
+                ]
+              },
+              {
+                "name": "isdiffpos",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "name": "tblid",
+                "type": [
+                  "long",
+                  "null"
+                ]
+              },
+              {
+                "name": "nid",
+                "type": [
+                  "int",
+                  "null"
+                ]
+              },
+              {
+                "name": "rcid",
+                "type": [
+                  "int",
+                  "null"
+                ]
+              },
+              {
+                "name": "field",
+                "type": [
+                  "int",
+                  "null"
+                ]
+              },
+              {
+                "name": "xpos",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "ypos",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "ra",
+                "type": [
+                  "double",
+                  "null"
+                ]
+              },
+              {
+                "name": "dec",
+                "type": [
+                  "double",
+                  "null"
+                ]
+              },
+              {
+                "name": "magpsf",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "sigmapsf",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "chipsf",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "magap",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "sigmagap",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "distnr",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "magnr",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "sigmagnr",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "chinr",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "sharpnr",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "sky",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "magdiff",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "fwhm",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "classtar",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "mindtoedge",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "magfromlim",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "seeratio",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "aimage",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "bimage",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "aimagerat",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "bimagerat",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "elong",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "nneg",
+                "type": [
+                  "int",
+                  "null"
+                ]
+              },
+              {
+                "name": "nbad",
+                "type": [
+                  "int",
+                  "null"
+                ]
+              },
+              {
+                "name": "rb",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "ssdistnr",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "ssmagnr",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "ssnamenr",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "name": "sumrat",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "magapbig",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "sigmagapbig",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "ranr",
+                "type": [
+                  "double",
+                  "null"
+                ]
+              },
+              {
+                "name": "decnr",
+                "type": [
+                  "double",
+                  "null"
+                ]
+              },
+              {
+                "name": "scorr",
+                "type": [
+                  "double",
+                  "null"
+                ]
+              },
+              {
+                "name": "magzpsci",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "magzpsciunc",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "magzpscirms",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "clrcoeff",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "clrcounc",
+                "type": [
+                  "float",
+                  "null"
+                ]
+              },
+              {
+                "name": "rbversion",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "null"
+      ]
+    },
+    {
+      "name": "cutoutScience",
+      "type": {
+        "type": "record",
+        "name": "cutoutScience",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "cutoutTemplate",
+      "type": {
+        "type": "record",
+        "name": "cutoutTemplate",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "cutoutDifference",
+      "type": {
+        "type": "record",
+        "name": "cutoutDifference",
+        "namespace": "topLevelRecord",
+        "fields": [
+          {
+            "name": "fileName",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "stampData",
+            "type": [
+              "bytes",
+              "null"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "topic",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "cdsxmatch",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "rfscore",
+      "type": [
+        "double",
+        "null"
+      ]
+    },
+    {
+      "name": "publisher",
+      "type": "string"
+    }
+  ]
+}


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #318

## What changes were proposed in this pull request?

This PR adds a new processor `rfscore` to compute the probability of an alert to be a SN Ia. The classification is based on the Machine Learning Random Forest algorithm. See #318 and https://github.com/astrolabsoftware/fink-science/pull/15 for the implementation. To work, this new feature requires `fink-science>=0.1.8` installed.

Note that the introduction of a new science module gives rise to a new schema for alert distribution (a new field is added). After the merging, the distribution schema will be `schemas/distribution_schema_0p2.avsc`.

Minor:
* Add two new dependencies in the requirements: scipy and scikit-learn
* Fix numpy version in the requirements.txt to satisfy Scipy requirements.

## How was this patch tested?

Manually and CI