### PR TITLE
add missing ${EXTRA_SPARK_CONFIG} for the distribution job

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -270,7 +270,7 @@ elif [[ $service == "distribution" ]]; then
   # Start the Spark Producer
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
-  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
   --files ${FINK_HOME}/conf/fink_kafka_producer_jaas.conf \
   --driver-java-options "-Djava.security.auth.login.config=${FINK_PRODUCER_JAAS}" \
   --conf "spark.driver.extraJavaOptions=-Djava.security.auth.login.config=${FINK_PRODUCER_JAAS}" \


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #328 

## What changes were proposed in this pull request?

This PR adds the missing ${EXTRA_SPARK_CONFIG} argument in the distribution job to correctly propagate resources requirements.

## How was this patch tested?

On the cluster