### PR TITLE
[Science portal] Ingest science data to HBase

### DIFF
--- a/bin/access_science_db.py
+++ b/bin/access_science_db.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# Copyright 2019 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Access the science database, and read alerts. HBase must be installed.
+"""
+import argparse
+import time
+import json
+
+from fink_broker.parser import getargs
+from fink_broker.sparkUtils import init_sparksession
+from fink_broker.loggingUtils import get_fink_logger, inspect_application
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = getargs(parser)
+
+    # Grab the running Spark Session,
+    # otherwise create it.
+    spark = init_sparksession(
+        name="readingScienceDB", shuffle_partitions=2)
+
+    # The level here should be controlled by an argument.
+    logger = get_fink_logger(spark.sparkContext.appName, args.log_level)
+
+    # debug statements
+    inspect_application(logger)
+
+    with open(args.science_db_catalog) as f:
+        catalog = json.load(f)
+
+    catalog_dic = json.loads(catalog)
+
+    df = spark.read.option("catalog", catalog)\
+        .format("org.apache.spark.sql.execution.datasources.hbase")\
+        .load()
+
+    print("Number of entries in {}: ".format(
+        catalog_dic["table"]["name"]), df.count())
+
+    print("Number of distinct objects in {}: ".format(
+        catalog_dic["table"]["name"]), df.select('objectId').distinct().count())
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/fink
+++ b/bin/fink
@@ -15,7 +15,7 @@
 # limitations under the License.
 set -e
 
-message_service="Available services are: checkstream, stream2raw, raw2science, distribution"
+message_service="Available services are: checkstream, stream2raw, raw2science, distribution, science_archival, check_science_portal"
 message_conf="Typical configuration would be $PWD/conf/fink.conf"
 message_help="""
 Handle Kafka stream received by Apache Spark\n\n

--- a/bin/fink
+++ b/bin/fink
@@ -283,6 +283,35 @@ elif [[ $service == "distribution" ]]; then
   -distribution_schema ${DISTRIBUTION_SCHEMA} \
   -distribution_rules_xml "${DISTRIBUTION_RULES_XML}" \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
+elif [[ $service == "science_archival" ]]; then
+  # Read configuration for hbase
+  source ${FINK_HOME}/conf/fink.conf.hbase
+  # Check if the use wants to just drop the catalog on disk
+  if [[ "$SAVE_SCIENCE_DB_CATALOG_ONLY" = true ]] ; then
+    SAVE_SCIENCE_DB_CATALOG_ONLY="--save_science_db_catalog_only"
+  else
+    SAVE_SCIENCE_DB_CATALOG_ONLY=""
+  fi
+
+  spark-submit --master ${SPARK_MASTER} \
+  --packages ${FINK_PACKAGES} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
+  ${FINK_HOME}/bin/science_archival.py ${HELP_ON_SERVICE} \
+  -science_db_name ${SCIENCE_DB_NAME} \
+  -science_db_catalog ${SCIENCE_DB_CATALOG} \
+  ${SAVE_SCIENCE_DB_CATALOG_ONLY} \
+  -night_to_archive ${NIGHT_TO_ARCHIVE} \
+  -log_level ${LOG_LEVEL} ${EXIT_AFTER}
+elif [[ $service == "check_science_portal" ]]; then
+  # Read configuration for hbase
+  source ${FINK_HOME}/conf/fink.conf.hbase
+
+  spark-submit --master ${SPARK_MASTER} \
+  --packages ${FINK_PACKAGES} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
+  ${FINK_HOME}/bin/access_science_db.py ${HELP_ON_SERVICE} \
+  -science_db_catalog ${SCIENCE_DB_CATALOG} \
+  -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "distribution_test" ]]; then
   # Read configuration for redistribution
   source ${FINK_HOME}/conf/fink.conf.distribution

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -115,6 +115,10 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
 
   # Connect to distribution service
   fink start distribution --exit_after 30 -c $conf
+
+  fink start science_archival -c $conf
+
+  fink start check_science_portal -c $conf
 fi
 
 # Combine individual reports in one

--- a/bin/science_archival.py
+++ b/bin/science_archival.py
@@ -77,12 +77,11 @@ def main():
     hbcatalog = construct_hbase_catalog_from_flatten_schema(
         df.schema, args.science_db_name, rowkey="rowkey", cf=cf)
 
-    print(args.save_science_db_catalog_only, type(args.save_science_db_catalog_only))
-    if args.save_science_db_catalog_only:
-        # Save the catalog on disk (local)
-        with open(args.science_db_catalog, 'w') as json_file:
-            json.dump(hbcatalog, json_file)
+    # Save the catalog on disk (local)
+    with open(args.science_db_catalog, 'w') as json_file:
+        json.dump(hbcatalog, json_file)
 
+    if args.save_science_db_catalog_only:
         # Print for visual inspection
         print(hbcatalog)
     else:

--- a/bin/science_archival.py
+++ b/bin/science_archival.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# Copyright 2020 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Push science data to the science portal (HBase table)
+
+1. Use the Alert data that is stored in the Science TMP database (Parquet)
+2. Extract relevant information from alerts
+3. Construct HBase catalog
+4. Push data (single shot)
+"""
+from pyspark.sql.functions import lit
+
+import argparse
+import time
+import json
+
+from fink_broker.parser import getargs
+from fink_broker.sparkUtils import init_sparksession, load_parquet_files
+
+from fink_broker.hbaseUtils import construct_hbase_catalog_from_flatten_schema
+from fink_broker.hbaseUtils import load_science_portal_column_names
+from fink_broker.hbaseUtils import assign_column_family_names
+from fink_broker.hbaseUtils import attach_rowkey
+
+from fink_broker.loggingUtils import get_fink_logger, inspect_application
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = getargs(parser)
+
+    # Initialise Spark session
+    spark = init_sparksession(name="science_archival", shuffle_partitions=2)
+
+    # The level here should be controlled by an argument.
+    logger = get_fink_logger(spark.sparkContext.appName, args.log_level)
+
+    # debug statements
+    inspect_application(logger)
+
+    # Connect to the TMP science database
+    df = load_parquet_files(args.night_to_archive)
+
+    # Drop partitioning columns
+    df = df.drop('year').drop('month').drop('day').drop('hour')
+
+    # Switch publisher
+    df = df.withColumn('publisher-tmp', lit('Fink')) \
+        .drop('publisher') \
+        .withColumnRenamed('publisher-tmp', 'publisher')
+
+    # Load column names to use in the science portal
+    cols_i, cols_d, cols_b = load_science_portal_column_names()
+
+    # Assign each column to a specific column family
+    cf = assign_column_family_names(df, cols_i, cols_d, cols_b)
+
+    # Restrict the input DataFrame to the subset of wanted columns.
+    df = df.select(cols_i + cols_d + cols_b)
+
+    # Create and attach the rowkey
+    df = attach_rowkey(df)
+
+    # construct the hbase catalog
+    hbcatalog = construct_hbase_catalog_from_flatten_schema(
+        df.schema, args.science_db_name, rowkey="rowkey", cf=cf)
+
+    print(args.save_science_db_catalog_only, type(args.save_science_db_catalog_only))
+    if args.save_science_db_catalog_only:
+        # Save the catalog on disk (local)
+        with open(args.science_db_catalog, 'w') as json_file:
+            json.dump(hbcatalog, json_file)
+
+        # Print for visual inspection
+        print(hbcatalog)
+    else:
+        # TODO: we could check the hbcatalog is the same as the one
+        # specified by the user.
+        # Push the data using the shc connector
+        df.write\
+            .options(catalog=hbcatalog, newtable=5)\
+            .format("org.apache.spark.sql.execution.datasources.hbase")\
+            .save()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/science_archival.py
+++ b/bin/science_archival.py
@@ -71,11 +71,11 @@ def main():
     df = df.select(cols_i + cols_d + cols_b)
 
     # Create and attach the rowkey
-    df = attach_rowkey(df)
+    df, row_key_name = attach_rowkey(df)
 
     # construct the hbase catalog
     hbcatalog = construct_hbase_catalog_from_flatten_schema(
-        df.schema, args.science_db_name, rowkey="rowkey", cf=cf)
+        df.schema, args.science_db_name, rowkeyname=row_key_name, cf=cf)
 
     # Save the catalog on disk (local)
     with open(args.science_db_catalog, 'w') as json_file:

--- a/conf/fink.conf.hbase
+++ b/conf/fink.conf.hbase
@@ -20,7 +20,7 @@
 LOG_LEVEL=INFO
 
 # Path to the night to archive
-NIGHT_TO_ARCHIVE='archive/alerts_store_tmp/year\=2020/month\=01/day\=06'
+NIGHT_TO_ARCHIVE='archive/alerts_store_tmp'
 
 # The name of the HBase table (must exist)
 SCIENCE_DB_NAME="test_portal"

--- a/conf/fink.conf.hbase
+++ b/conf/fink.conf.hbase
@@ -1,0 +1,30 @@
+# Copyright 2020 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+######################################
+# Configurations for pushing data to the Science Portal
+
+# The minimum level of log for FINK: OFF, DEBUG, INFO, WARN, ERROR, CRITICAL
+# Note that for Spark, the level is set to WARN (see log4j.properties)
+LOG_LEVEL=INFO
+
+# Path to the night to archive
+NIGHT_TO_ARCHIVE='archive/alerts_store_tmp/year\=2020/month\=01/day\=06'
+
+# The name of the HBase table (must exist)
+SCIENCE_DB_NAME="test_portal"
+
+# For debug - careful false/true must be small letters
+SAVE_SCIENCE_DB_CATALOG_ONLY=false
+SCIENCE_DB_CATALOG=${FINK_HOME}/catalog_hbase.json

--- a/conf/install_hbase.sh
+++ b/conf/install_hbase.sh
@@ -26,5 +26,5 @@ cp conf/hbase-site.xml hbase-${HBASE_VERSION}/conf/
 hbase-${HBASE_VERSION}/bin/start-hbase.sh
 
 # create a fake table for tests
-source conf/fink.conf.hbase
-echo -e "create '$SCIENCE_DB_NAME', 'i', 'd', 'b'" | hbase-${HBASE_VERSION}/bin/hbase shell -n
+# source conf/fink.conf.hbase
+# echo -e "create '$SCIENCE_DB_NAME', 'i', 'd', 'b'" | hbase-${HBASE_VERSION}/bin/hbase shell -n

--- a/conf/install_hbase.sh
+++ b/conf/install_hbase.sh
@@ -26,4 +26,5 @@ cp conf/hbase-site.xml hbase-${HBASE_VERSION}/conf/
 hbase-${HBASE_VERSION}/bin/start-hbase.sh
 
 # create a fake table for tests
-echo -e "create 'test_portal', 'i', 'd', 'b'" | hbase shell -n
+source conf/fink.conf.hbase
+echo -e "create '$SCIENCE_DB_NAME', 'i', 'd', 'b'" | hbase-${HBASE_VERSION}/bin/hbase shell -n

--- a/conf/install_hbase.sh
+++ b/conf/install_hbase.sh
@@ -24,3 +24,6 @@ rm hbase-${HBASE_VERSION}-bin.tar.gz
 cp conf/hbase-site.xml hbase-${HBASE_VERSION}/conf/
 
 hbase-${HBASE_VERSION}/bin/start-hbase.sh
+
+# create a fake table for tests
+echo -e "create 'test_portal', 'i', 'd', 'b'" | hbase shell -n

--- a/conf/install_kafka.sh
+++ b/conf/install_kafka.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 set -e
 
-KAFKA_VERSION=2.2.0
+KAFKA_VERSION=2.4.1
 
 wget https://www.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_2.12-${KAFKA_VERSION}.tgz -O kafka.tgz
 mkdir -p kafka

--- a/fink_broker/hbaseUtils.py
+++ b/fink_broker/hbaseUtils.py
@@ -269,8 +269,7 @@ def explodearrayofstruct(df: DataFrame, columnname: str) -> DataFrame:
     df_flatten = _java2py(sc, _df)
     return df_flatten
 
-def write_to_hbase_and_monitor(
-        df: DataFrame, epochid: int, hbcatalog: str):
+def write_to_hbase_and_monitor(df: DataFrame, epochid: int, hbcatalog: str):
     """Write data into HBase.
 
     The purpose of this function is to write data to HBase using

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -219,7 +219,14 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         '-night_to_archive', type=str, default='',
         help="""
         Path to the nightly data to archive in HBase.
-        [SLACK_CHANNELS]
+        [NIGHT_TO_ARCHIVE]
+        """)
+    parser.add_argument(
+        '--save_science_db_catalog_only', action='store_true',
+        help="""
+        If True, save only the catalog on disk and do not push
+        data on HBase. Default is False.
+        [SAVE_SCIENCE_DB_CATALOG_ONLY]
         """)
     args = parser.parse_args(None)
     return args

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -215,6 +215,12 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         must be sent for e.g. based on cross-match type
         [SLACK_CHANNELS]
         """)
+    parser.add_argument(
+        '-night_to_archive', type=str, default='',
+        help="""
+        Path to the nightly data to archive in HBase.
+        [SLACK_CHANNELS]
+        """)
     args = parser.parse_args(None)
     return args
 

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -309,6 +309,38 @@ def connect_to_raw_database(
 
     return df
 
+def load_parquet_files(path: str) -> DataFrame:
+    """ Initialise SparkSession, and load parquet files with Spark
+
+    Unlike connect_to_raw_database, you get a standard DataFrame, and
+    not a Streaming DataFrame.
+
+    Parameters
+    ----------
+    path: str
+        The path to the data
+
+    Returns
+    ----------
+    df: DataFrame
+        Spark SQL DataFrame
+
+    Examples
+    ----------
+    >>> df = load_parquet_files("archive/alerts_store")
+    """
+    # Grab the running Spark Session
+    spark = SparkSession \
+        .builder \
+        .getOrCreate()
+
+    df = spark \
+        .read \
+        .format("parquet") \
+        .load(path)
+
+    return df
+
 def get_schemas_from_avro(
         avro_path: str) -> (StructType, dict, str):
     """ Build schemas from an avro file (DataFrame & JSON compatibility)


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #347, #348, #350 

## What changes were proposed in this pull request?

This PR brings two new script to interact with the science portal (#347 ):
- `fink start science_archival` which takes data from a particular night (to be define in the configuration file `conf/fink.conf.hbase`) and push it to HBase.
- `fink start check_science_portal` which load the HBase table into a Spark DataFrame and do some sanity checks.

In addition, the user have the possibility to just output the HBase catalog for inspection (one part of #350).

Finally, a small bug has been fixed (Kafka version, #348 ).

## How was this patch tested?

Manually and CI. New unit tests, and integration tests were added.

## Further work

It would be good to:
- [ ] sanitize all the configuration files (redundant variables)
- [x] clean `hbaseutils.py` from unused routines.
