### PR TITLE
[Science Portal] Push a schema row while updating the science portal

### DIFF
--- a/bin/science_archival.py
+++ b/bin/science_archival.py
@@ -109,7 +109,8 @@ def main():
             cf=cf)
 
         # Save the catalog on disk (local)
-        with open(args.science_db_catalog + '_schema_row', 'w') as json_file:
+        catname = args.science_db_catalog.replace('.json', '_schema_row.json')
+        with open(catname, 'w') as json_file:
             json.dump(hbcatalog_schema, json_file)
 
         # Push the data using the shc connector

--- a/bin/science_archival.py
+++ b/bin/science_archival.py
@@ -34,6 +34,7 @@ from fink_broker.hbaseUtils import construct_hbase_catalog_from_flatten_schema
 from fink_broker.hbaseUtils import load_science_portal_column_names
 from fink_broker.hbaseUtils import assign_column_family_names
 from fink_broker.hbaseUtils import attach_rowkey
+from fink_broker.hbaseUtils import construct_schema_row
 
 from fink_broker.loggingUtils import get_fink_logger, inspect_application
 
@@ -85,11 +86,35 @@ def main():
         # Print for visual inspection
         print(hbcatalog)
     else:
-        # TODO: we could check the hbcatalog is the same as the one
-        # specified by the user.
         # Push the data using the shc connector
         df.write\
             .options(catalog=hbcatalog, newtable=5)\
+            .format("org.apache.spark.sql.execution.datasources.hbase")\
+            .save()
+
+        # Construct the schema row - inplace replacement
+        schema_row_key_name = 'schema_version'
+        df = df.withColumnRenamed(row_key_name, schema_row_key_name)
+
+        df_schema = construct_schema_row(
+            df,
+            rowkeyname=schema_row_key_name,
+            version='schema_v0')
+
+        # construct the hbase catalog for the schema
+        hbcatalog_schema = construct_hbase_catalog_from_flatten_schema(
+            df_schema.schema,
+            args.science_db_name,
+            rowkeyname=schema_row_key_name,
+            cf=cf)
+
+        # Save the catalog on disk (local)
+        with open(args.science_db_catalog + '_schema_row', 'w') as json_file:
+            json.dump(hbcatalog_schema, json_file)
+
+        # Push the data using the shc connector
+        df_schema.write\
+            .options(catalog=hbcatalog_schema, newtable=5)\
             .format("org.apache.spark.sql.execution.datasources.hbase")\
             .save()
 

--- a/fink_broker/hbaseUtils.py
+++ b/fink_broker/hbaseUtils.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import concat_ws, col
+from pyspark.sql.functions import concat_ws, col, lit
 from pyspark.mllib.common import _java2py
+from pyspark.sql import SparkSession
+
+import numpy as np
 
 import os
 
@@ -260,6 +263,61 @@ def construct_hbase_catalog_from_flatten_schema(
     """
 
     return catalog.replace("\'", "\"")
+
+def construct_schema_row(df, rowkeyname, version):
+    """ Construct a DataFrame whose columns are those of the
+    original ones, and one row containing schema types
+
+    Parameters
+    ----------
+    df: Spark DataFrame
+        Input Spark DataFrame. Need to be flattened.
+    rowkeyname: string
+        Name of the HBase row key (column name)
+    version: string
+        Version of the HBase table (row value for the rowkey column).
+
+    Returns
+    ---------
+    df_schema: Spark DataFrame
+        Spark DataFrame with one row (the types of its column). Only the row
+        key is the version of the HBase table.
+
+    Examples
+    --------
+    # Read alert from the raw database
+    >>> df_raw = spark.read.format("parquet").load(ztf_alert_sample_rawdatabase)
+
+    # Select alert data and Kafka publication timestamp
+    >>> df = df_raw.select("decoded.*", "timestamp")
+
+    # inplace replacement
+    >>> df = df.select(['objectId', 'candidate.jd', 'candidate.candid'])
+    >>> df = df.withColumn('schema_version', lit(''))
+    >>> df = construct_schema_row(df, rowkeyname='schema_version', version='schema_v0')
+    >>> df.show()
+    +--------+------+------+--------------+
+    |objectId|    jd|candid|schema_version|
+    +--------+------+------+--------------+
+    |  string|double|  long|     schema_v0|
+    +--------+------+------+--------------+
+    """
+    # Grab the running Spark Session,
+    # otherwise create it.
+    spark = SparkSession \
+        .builder \
+        .getOrCreate()
+
+    # Original df columns, but values are types.
+    data = [(c.jsonValue()['type']) for c in df.schema]
+
+    index = np.where(np.array(df.columns) == rowkeyname)[0][0]
+    data[index] = version
+
+    # Create the DataFrame
+    df_schema = spark.createDataFrame([data], df.columns)
+
+    return df_schema
 
 def flattenstruct(df: DataFrame, columnname: str) -> DataFrame:
     """ From a nested column (struct of primitives),

--- a/fink_broker/hbaseUtils.py
+++ b/fink_broker/hbaseUtils.py
@@ -301,6 +301,7 @@ def construct_schema_row(df, rowkeyname, version):
     +--------+------+------+--------------+
     |  string|double|  long|     schema_v0|
     +--------+------+------+--------------+
+    <BLANKLINE>
     """
     # Grab the running Spark Session,
     # otherwise create it.


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #355 

## What changes were proposed in this pull request?

This PR allows the `science_archival` service to push a schema row to the HBase table. This schema row describes the types of available columns. It is versioned.

## How was this patch tested?

Manually (local HBase table)