### PR TITLE
New partitioning strategy

### DIFF
--- a/bin/distribute.py
+++ b/bin/distribute.py
@@ -56,7 +56,7 @@ def main():
         args.scitmpdatapath, args.scitmpdatapath + "/*", latestfirst=False)
 
     # Drop partitioning columns
-    df = df.drop('year').drop('month').drop('day').drop('hour')
+    df = df.drop('year').drop('month').drop('day')
 
     # Switch publisher
     df = df.withColumn('publisher-tmp', lit('Fink')) \

--- a/bin/fink
+++ b/bin/fink
@@ -292,9 +292,11 @@ elif [[ $service == "merge_and_clean" ]]; then
   --packages ${FINK_PACKAGES} \
   --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
   ${FINK_HOME}/bin/merge_ztf_day.py ${HELP_ON_SERVICE} \
+  -datapath ${DATA_PREFIX} \
   -rawdatapath ${FINK_ALERT_PATH} \
   -scitmpdatapath ${FINK_ALERT_PATH_SCI_TMP} \
   -night ${NIGHT} \
+  -fs ${FS_KIND} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "science_archival" ]]; then
   # Read configuration for hbase

--- a/bin/fink
+++ b/bin/fink
@@ -102,6 +102,10 @@ while [ "$#" -gt 0 ]; do
         python3 -c "import fink_broker; print(fink_broker.__version__)"
         exit
         ;;
+    --night)
+      NIGHT="$2"
+      shift 2
+      ;;
     --exit_after)
         EXIT_AFTER="-exit_after $2"
         shift 2
@@ -283,6 +287,15 @@ elif [[ $service == "distribution" ]]; then
   -distribution_schema ${DISTRIBUTION_SCHEMA} \
   -distribution_rules_xml "${DISTRIBUTION_RULES_XML}" \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
+elif [[ $service == "merge_and_clean" ]]; then
+  spark-submit --master ${SPARK_MASTER} \
+  --packages ${FINK_PACKAGES} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
+  ${FINK_HOME}/bin/merge_ztf_day.py ${HELP_ON_SERVICE} \
+  -rawdatapath ${FINK_ALERT_PATH} \
+  -scitmpdatapath ${FINK_ALERT_PATH_SCI_TMP} \
+  -night ${NIGHT} \
+  -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "science_archival" ]]; then
   # Read configuration for hbase
   source ${FINK_HOME}/conf/fink.conf.hbase
@@ -300,7 +313,7 @@ elif [[ $service == "science_archival" ]]; then
   -science_db_name ${SCIENCE_DB_NAME} \
   -science_db_catalog ${SCIENCE_DB_CATALOG} \
   ${SAVE_SCIENCE_DB_CATALOG_ONLY} \
-  -night_to_archive ${NIGHT_TO_ARCHIVE} \
+  -night ${NIGHT} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "check_science_portal" ]]; then
   # Read configuration for hbase

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -116,6 +116,9 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   # Connect to distribution service
   fink start distribution --exit_after 30 -c $conf
 
+  # merge and clean data
+  fink start merge_and_clean -c conf/fink.conf.travis --night "20190903"
+
   fink start science_archival -c $conf
 
   fink start check_science_portal -c $conf

--- a/bin/merge_ztf_day.py
+++ b/bin/merge_ztf_day.py
@@ -55,7 +55,7 @@ def main():
     input_raw = '{}/year={}/month={}/day={}'.format(
         args.rawdatapath, year, month, day)
     input_science = '{}/year={}/month={}/day={}'.format(
-        args.scitmpdatapath, year, month[1:], day[1:])
+        args.scitmpdatapath, year, month, day)
 
     # they do not need to exist
     output_raw = 'ztf_{}/raw'.format(year)

--- a/bin/merge_ztf_day.py
+++ b/bin/merge_ztf_day.py
@@ -21,6 +21,7 @@ from pyspark.sql import functions as F
 import argparse
 import time
 import json
+import subprocess
 
 from fink_broker.parser import getargs
 from fink_broker.sparkUtils import init_sparksession
@@ -89,6 +90,14 @@ def main():
         .mode("append") \
         .partitionBy("month", "day")\
         .parquet(output_science)
+
+    # Remove temporary alert folder - beware you'll never get it back!
+    if args.fs == 'hdfs':
+        subprocess.run(["hdfs", "dfs", '-rm', '-rf', args.datapath])
+    elif args.fs == 'local':
+        subprocess.run(['rm', '-rf', args.datapath])
+    else:
+        print('Filesystem not understood. FS_KIND must be hdfs or local.')
 
 
 if __name__ == "__main__":

--- a/bin/merge_ztf_day.py
+++ b/bin/merge_ztf_day.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# Copyright 2020 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Retrieve one ZTF day, and merge small files into larger ones.
+"""
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+
+import argparse
+import time
+import json
+
+from fink_broker.parser import getargs
+from fink_broker.sparkUtils import init_sparksession
+from fink_broker.partitioning import jd_to_datetime, numPart
+from fink_broker.loggingUtils import get_fink_logger, inspect_application
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = getargs(parser)
+
+    # Initialise Spark session
+    spark = init_sparksession(name="mergeAndClean")
+
+    # Logger to print useful debug statements
+    logger = get_fink_logger(spark.sparkContext.appName, args.log_level)
+
+    # debug statements
+    inspect_application(logger)
+
+    year = args.night[:4]
+    month = args.night[4:6]
+    day = args.night[6:8]
+
+    print('Processing {}/{}/{}'.format(year, month, day))
+
+    # Uncomment to move old data
+    # input_raw = 'ztf_{}{}/alerts_store/topic=ztf_{}{}{}_programid1/year={}/month={}/day={}'.format(
+    #     year, month, year, month, day, year, month, day)
+    # input_science = 'ztf_{}{}/alerts_store_tmp/year={}/month={}/day={}'.format(
+    #     year, month, year, month, day)
+
+    input_raw = '{}/year={}/month={}/day={}'.format(
+        args.rawdatapath, year, month, day)
+    input_science = '{}/year={}/month={}/day={}'.format(
+        args.scitmpdatapath, year, month[1:], day[1:])
+
+    # they do not need to exist
+    output_raw = 'ztf_{}/raw'.format(year)
+    output_science = 'ztf_{}/science'.format(year)
+
+    print('Raw data processing....')
+    df_raw = spark.read.format('parquet').load(input_raw)
+    print('Num partitions before: ', df_raw.rdd.getNumPartitions())
+    print('Num partitions after : ', numPart(df_raw))
+
+    df_raw.withColumn('ts_jd', jd_to_datetime(df_raw['candidate.jd']))\
+        .withColumn("month", F.date_format("ts_jd", "MM"))\
+        .withColumn("day", F.date_format("ts_jd", "dd"))\
+        .coalesce(numPart(df_raw))\
+        .write\
+        .mode("append") \
+        .partitionBy("month", "day")\
+        .parquet(output_raw)
+
+    print('Science data processing....')
+
+    df_science = spark.read.format('parquet').load(input_science)
+    print('Num partitions before: ', df_science.rdd.getNumPartitions())
+    print('Num partitions after : ', numPart(df_science))
+
+    df_science.withColumn('ts_jd', jd_to_datetime(df_science['candidate.jd']))\
+        .withColumn("month", F.date_format("ts_jd", "MM"))\
+        .withColumn("day", F.date_format("ts_jd", "dd"))\
+        .coalesce(numPart(df_science))\
+        .write\
+        .mode("append") \
+        .partitionBy("month", "day")\
+        .parquet(output_science)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/raw2science.py
+++ b/bin/raw2science.py
@@ -116,21 +116,14 @@ def main():
     # Drop temp columns
     df = df.drop(*what_prefix)
 
-    # Partition the data hourly
-    df_partitionedby = df\
-        .withColumn("year", F.date_format("timestamp", "yyyy"))\
-        .withColumn("month", F.date_format("timestamp", "MM"))\
-        .withColumn("day", F.date_format("timestamp", "dd"))\
-        .withColumn("hour", F.date_format("timestamp", "HH"))
-
     # Append new rows in the tmp science database
-    countquery = df_partitionedby\
+    countquery = df\
         .writeStream\
         .outputMode("append") \
         .format("parquet") \
         .option("checkpointLocation", args.checkpointpath_sci_tmp) \
         .option("path", args.scitmpdatapath)\
-        .partitionBy("year", "month", "day", "hour") \
+        .partitionBy("year", "month", "day") \
         .start()
 
     # Keep the Streaming running until something or someone ends it!

--- a/bin/raw2science.py
+++ b/bin/raw2science.py
@@ -116,8 +116,15 @@ def main():
     # Drop temp columns
     df = df.drop(*what_prefix)
 
+    # re-create partitioning columns.
+    # Partitioned data doesn't preserve type information (cast as int...)
+    df_partitionedby = df\
+        .withColumn("year", F.date_format("timestamp", "yyyy"))\
+        .withColumn("month", F.date_format("timestamp", "MM"))\
+        .withColumn("day", F.date_format("timestamp", "dd"))\
+
     # Append new rows in the tmp science database
-    countquery = df\
+    countquery = df_partitionedby\
         .writeStream\
         .outputMode("append") \
         .format("parquet") \

--- a/bin/raw2science.py
+++ b/bin/raw2science.py
@@ -121,7 +121,7 @@ def main():
     df_partitionedby = df\
         .withColumn("year", F.date_format("timestamp", "yyyy"))\
         .withColumn("month", F.date_format("timestamp", "MM"))\
-        .withColumn("day", F.date_format("timestamp", "dd"))\
+        .withColumn("day", F.date_format("timestamp", "dd"))
 
     # Append new rows in the tmp science database
     countquery = df_partitionedby\

--- a/bin/science_archival.py
+++ b/bin/science_archival.py
@@ -52,7 +52,12 @@ def main():
     inspect_application(logger)
 
     # Connect to the TMP science database
-    df = load_parquet_files(args.night_to_archive)
+    path = 'ztf_{}/science/month={}/day={}'.format(
+        args.night[:4],
+        args.night[4:6],
+        args.night[6:8]
+    )
+    df = load_parquet_files(path)
 
     # Drop partitioning columns
     df = df.drop('year').drop('month').drop('day').drop('hour')

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -74,12 +74,12 @@ FS_KIND=local
 DATA_PREFIX=${FINK_HOME}/archive
 
 # Internal. Do not touch unless you know what you are doing
-FINK_ALERT_PATH=${DATA_PREFIX}/alerts_store
-FINK_ALERT_PATH_SCI_TMP=${DATA_PREFIX}/alerts_store_tmp
-FINK_ALERT_CHECKPOINT_RAW=${DATA_PREFIX}/alerts_raw_checkpoint
-FINK_ALERT_CHECKPOINT_SCI_TMP=${DATA_PREFIX}/alerts_sci_tmp_checkpoint
+FINK_ALERT_PATH=${DATA_PREFIX}/raw
+FINK_ALERT_PATH_SCI_TMP=${DATA_PREFIX}/science
+FINK_ALERT_CHECKPOINT_RAW=${DATA_PREFIX}/raw_checkpoint
+FINK_ALERT_CHECKPOINT_SCI_TMP=${DATA_PREFIX}/science_checkpoint
 FINK_ALERT_CHECKPOINT_SCI=${DATA_PREFIX}/alerts_sci_checkpoint
-FINK_ALERT_CHECKPOINT_KAFKA=${DATA_PREFIX}/alerts_sci_kafka
+FINK_ALERT_CHECKPOINT_KAFKA=${DATA_PREFIX}/kafka_checkpoint
 
 # The name of the HBase table
 SCIENCE_DB_NAME="test_catalog"

--- a/conf/fink.conf.cluster
+++ b/conf/fink.conf.cluster
@@ -74,12 +74,12 @@ FS_KIND=hdfs
 DATA_PREFIX=""
 
 # Internal. Do not touch unless you know what you are doing
-FINK_ALERT_PATH=${DATA_PREFIX}/alerts_store
-FINK_ALERT_PATH_SCI_TMP=${DATA_PREFIX}/alerts_store_tmp
-FINK_ALERT_CHECKPOINT_RAW=${DATA_PREFIX}/alerts_raw_checkpoint
-FINK_ALERT_CHECKPOINT_SCI_TMP=${DATA_PREFIX}/alerts_sci_tmp_checkpoint
+FINK_ALERT_PATH=${DATA_PREFIX}/raw
+FINK_ALERT_PATH_SCI_TMP=${DATA_PREFIX}/science
+FINK_ALERT_CHECKPOINT_RAW=${DATA_PREFIX}/raw_checkpoint
+FINK_ALERT_CHECKPOINT_SCI_TMP=${DATA_PREFIX}/science_checkpoint
 FINK_ALERT_CHECKPOINT_SCI=${DATA_PREFIX}/alerts_sci_checkpoint
-FINK_ALERT_CHECKPOINT_KAFKA=${DATA_PREFIX}/alerts_sci_kafka
+FINK_ALERT_CHECKPOINT_KAFKA=${DATA_PREFIX}/kafka_checkpoint
 
 # The name of the HBase table
 SCIENCE_DB_NAME=""

--- a/conf/fink.conf.hbase
+++ b/conf/fink.conf.hbase
@@ -20,7 +20,7 @@
 LOG_LEVEL=INFO
 
 # Path to the night to archive
-NIGHT_TO_ARCHIVE='archive/science'
+NIGHT='20190903'
 
 # The name of the HBase table (must exist)
 SCIENCE_DB_NAME="test_portal"

--- a/conf/fink.conf.hbase
+++ b/conf/fink.conf.hbase
@@ -20,7 +20,7 @@
 LOG_LEVEL=INFO
 
 # Path to the night to archive
-NIGHT_TO_ARCHIVE='archive/alerts_store_tmp'
+NIGHT_TO_ARCHIVE='archive/science'
 
 # The name of the HBase table (must exist)
 SCIENCE_DB_NAME="test_portal"

--- a/conf/fink.conf.travis
+++ b/conf/fink.conf.travis
@@ -74,12 +74,12 @@ FS_KIND=local
 DATA_PREFIX=${FINK_HOME}/archive
 
 # Internal. Do not touch unless you know what you are doing
-FINK_ALERT_PATH=${DATA_PREFIX}/alerts_store
-FINK_ALERT_PATH_SCI_TMP=${DATA_PREFIX}/alerts_store_tmp
-FINK_ALERT_CHECKPOINT_RAW=${DATA_PREFIX}/alerts_raw_checkpoint
-FINK_ALERT_CHECKPOINT_SCI_TMP=${DATA_PREFIX}/alerts_sci_tmp_checkpoint
+FINK_ALERT_PATH=${DATA_PREFIX}/raw
+FINK_ALERT_PATH_SCI_TMP=${DATA_PREFIX}/science
+FINK_ALERT_CHECKPOINT_RAW=${DATA_PREFIX}/raw_checkpoint
+FINK_ALERT_CHECKPOINT_SCI_TMP=${DATA_PREFIX}/science_checkpoint
 FINK_ALERT_CHECKPOINT_SCI=${DATA_PREFIX}/alerts_sci_checkpoint
-FINK_ALERT_CHECKPOINT_KAFKA=${DATA_PREFIX}/alerts_distribution_checkpoint
+FINK_ALERT_CHECKPOINT_KAFKA=${DATA_PREFIX}/kafka_checkpoint
 
 # The name of the HBase table
 SCIENCE_DB_NAME="test_travis"

--- a/fink_broker/filters.py
+++ b/fink_broker/filters.py
@@ -125,7 +125,7 @@ def return_flatten_names(
 
     Examples
     -------
-    >>> df = spark.read.format("parquet").load("archive/alerts_store")
+    >>> df = spark.read.format("parquet").load("archive/raw")
     >>> flatten_schema = return_flatten_names(df)
     >>> assert("candidate.candid" in flatten_schema)
     """

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -216,10 +216,10 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         [SLACK_CHANNELS]
         """)
     parser.add_argument(
-        '-night_to_archive', type=str, default='',
+        '-night', type=str, default='',
         help="""
-        Path to the nightly data to archive in HBase.
-        [NIGHT_TO_ARCHIVE]
+        YYYYMMDD night
+        [NIGHT]
         """)
     parser.add_argument(
         '--save_science_db_catalog_only', action='store_true',

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -222,6 +222,18 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         [NIGHT]
         """)
     parser.add_argument(
+        '-fs', type=str, default='',
+        help="""
+        Filesystem: local or hdfs.
+        [FS_KIND]
+        """)
+    parser.add_argument(
+        '-datapath', type=str, default='',
+        help="""
+        Directory on disk for saving temporary alert data.
+        [DATA_PREFIX]
+        """)
+    parser.add_argument(
         '--save_science_db_catalog_only', action='store_true',
         help="""
         If True, save only the catalog on disk and do not push

--- a/fink_broker/partitioning.py
+++ b/fink_broker/partitioning.py
@@ -73,7 +73,6 @@ def numPart(df, partition_size=128.):
     # otherwise create it.
     spark = SparkSession \
         .builder \
-        .appName(name) \
         .getOrCreate()
 
     b = spark._jsparkSession\

--- a/fink_broker/partitioning.py
+++ b/fink_broker/partitioning.py
@@ -1,0 +1,96 @@
+# Copyright 2020 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.types import TimestampType
+
+import numpy as np
+import pandas as pd
+from astropy.time import Time
+
+@pandas_udf(TimestampType(), PandasUDFType.SCALAR)
+def jd_to_datetime(jd: float):
+    """ Convert Julian date into datetime (timestamp)
+
+    Parameters
+    ----------
+    jd: double
+        Julian date
+
+    Returns
+    ----------
+    out: datetime
+        Datetime object
+
+    Examples
+    ----------
+    >>> from fink_broker.sparkUtils import load_parquet_files
+    >>> df = load_parquet_files("archive/raw")
+    >>> df.withColumn('datetime', jd_to_datetime(df['candidate.jd']))
+    """
+    return pd.Series(Time(jd.values, format='jd').to_datetime())
+
+def numPart(df, partition_size=128.):
+    """ Compute the idle number of partitions of a DataFrame
+    based on its size.
+
+    Parameters
+    ----------
+    partition_size: float
+        Size of a partition in MB
+
+    Returns
+    ----------
+    numpart: int
+        Number of partitions of size `partition_size` based
+        on the DataFrame size
+    partition_size: float, optional
+        Size of output partitions in MB
+
+    Examples
+    ----------
+    >>> from fink_broker.sparkUtils import load_parquet_files
+    >>> df = load_parquet_files("archive/raw")
+    >>> numpart = numPart(df, partition_size=128.)
+    >>> print(numpart)
+    1
+    """
+    # Grab the running Spark Session,
+    # otherwise create it.
+    spark = SparkSession \
+        .builder \
+        .appName(name) \
+        .getOrCreate()
+
+    b = spark._jsparkSession\
+        .sessionState()\
+        .executePlan(df._jdf.queryExecution().logical())\
+        .optimizedPlan()\
+        .stats()\
+        .sizeInBytes()
+
+    # Convert in MB
+    b_mb = b / 1024. / 1024.
+
+    # Ceil it
+    numpart = int(np.ceil(b_mb / partition_size))
+
+    return numpart
+
+
+if __name__ == "__main__":
+    """ Execute the test suite with SparkSession initialised """
+
+    # Run the Spark test suite
+    spark_unit_tests(globals())

--- a/fink_broker/partitioning.py
+++ b/fink_broker/partitioning.py
@@ -19,6 +19,8 @@ import numpy as np
 import pandas as pd
 from astropy.time import Time
 
+from fink_broker.tester import spark_unit_tests
+
 @pandas_udf(TimestampType(), PandasUDFType.SCALAR)
 def jd_to_datetime(jd: float):
     """ Convert Julian date into datetime (timestamp)

--- a/fink_broker/partitioning.py
+++ b/fink_broker/partitioning.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from pyspark.sql.functions import pandas_udf, PandasUDFType
 from pyspark.sql.types import TimestampType
+from pyspark.sql import SparkSession
 
 import numpy as np
 import pandas as pd
@@ -39,7 +40,7 @@ def jd_to_datetime(jd: float):
     ----------
     >>> from fink_broker.sparkUtils import load_parquet_files
     >>> df = load_parquet_files("archive/raw")
-    >>> df.withColumn('datetime', jd_to_datetime(df['candidate.jd']))
+    >>> df = df.withColumn('datetime', jd_to_datetime(df['candidate.jd']))
     """
     return pd.Series(Time(jd.values, format='jd').to_datetime())
 

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -139,7 +139,7 @@ def write_to_csv(
         .to_csv(fn, index=False)
     batchdf.unpersist()
 
-def init_sparksession(name: str, shuffle_partitions: int = 2) -> SparkSession:
+def init_sparksession(name: str, shuffle_partitions: int = None) -> SparkSession:
     """ Initialise SparkSession, the level of log for Spark and
     some configuration parameters
 
@@ -149,7 +149,8 @@ def init_sparksession(name: str, shuffle_partitions: int = 2) -> SparkSession:
         Name for the Spark Application.
     shuffle_partitions: int, optional
         Number of partition to use when shuffling data.
-        Typically better to keep the size of shuffles small. Default is 2.
+        Typically better to keep the size of shuffles small.
+        Default is None.
 
     Returns
     ----------
@@ -172,7 +173,8 @@ def init_sparksession(name: str, shuffle_partitions: int = 2) -> SparkSession:
         .getOrCreate()
 
     # keep the size of shuffles small
-    spark.conf.set("spark.sql.shuffle.partitions", shuffle_partitions)
+    if shuffle_partitions is not None:
+        spark.conf.set("spark.sql.shuffle.partitions", shuffle_partitions)
 
     # Set spark log level to WARN
     spark.sparkContext.setLogLevel("WARN")

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -283,7 +283,7 @@ def connect_to_raw_database(
     Examples
     ----------
     >>> dfstream_tmp = connect_to_raw_database(
-    ...   "archive/alerts_store", "archive/alerts_store/*", True)
+    ...   "archive/raw", "archive/raw/*", True)
     >>> dfstream_tmp.isStreaming
     True
     """
@@ -327,7 +327,7 @@ def load_parquet_files(path: str) -> DataFrame:
 
     Examples
     ----------
-    >>> df = load_parquet_files("archive/alerts_store")
+    >>> df = load_parquet_files("archive/raw")
     """
     # Grab the running Spark Session
     spark = SparkSession \


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #362, #334, #339, #340, #336

## What changes were proposed in this pull request?

### Old behavior, and limitations

In Fink, there are two orthogonal phases:
1. streaming (Spark Structured Streaming): real-time processing (many cores + small latencies) -> typically thousands of small files of ~1MB each night written on disks
2. post-processing (Spark SQL): manipulating several days of processed data

In both cases, data is partitioned over time:

```bash
year=YYYY/month=MM/day=DD/hour=HH
# part-00000-01558f3f-7c17-468c-8ad8-a02064d1be24.c000.snappy.parquet
# ...
```

The problem is that the many small files written by the 1st phase are introducing large delays while reading the data in the second phase: sometimes dozen of minutes just for the job to start doing anything concrete on a few GB of data! On the other hand, we cannot increase the size of the files in the first phase to directly accommodate the second phase:
- if using `repartition` or `coalesce` we would break the parallelism, 
- if increasing the trigger time we would lose the real-time constraints

### Proposal

I introduce a new job that aggregates the many small files at the end of the night and writes them elsewhere in larger, consolidated files (typically files of 128MB, driven by HDFS). The new structure is the following:

```bash
fink init # initialise a new temporary sink for the streaming job
# current/raw/YYYY/MM/DD
# current/science/YYYY/MM/DD

# Launch the broker, and process the night
fink start stream2raw
fink start raw2science

# At the end of the night, merge files and clean the temporary sink
fink start merge_and_clean
# ztf_YYYY/raw/MM/DD
# ztf_YYYY/science/MM/DD

# Finally push to HBase (and later Grafink)
fink start science_archival
```

The partitioning is again over time (but we dropped `HH` which was not relevant), but the number of partitioned files is determined dynamically based on the night DataFrame size (~128 MB per file). Finally, the long-term parquet database on HDFS would be structured as:

```
ztf_YYYY/raw/month=MM/day=DD
ztf_YYYY/science/month=MM/day=DD
```

- [x] restructure `stream2raw` & `raw2science`
- [x] update configuration files
- [x] introduce new script to merge data, and update `bin/fink` to launch it
- [x] update the test suite
- [ ] reprocess all historical data

## How was this patch tested?

Manually and CI