### PR TITLE
[Merge] Use a fix basepath and add YYYY in the partition tree

### DIFF
--- a/bin/science_archival.py
+++ b/bin/science_archival.py
@@ -52,7 +52,7 @@ def main():
     inspect_application(logger)
 
     # Connect to the TMP science database
-    path = 'ztf_{}/science/month={}/day={}'.format(
+    path = 'ztf_alerts/science/year={}/month={}/day={}'.format(
         args.night[:4],
         args.night[4:6],
         args.night[6:8]


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #372 

## What changes were proposed in this pull request?

Use a fix basepath (`ztf_alerts/{raw/science}`) and add year information (`YYYY`) in the partition tree when merging streaming data.

## How was this patch tested?

Manually
