### PR TITLE
Remove topic column, and rename ts_jd into timestamp

### DIFF
--- a/bin/merge_ztf_night.py
+++ b/bin/merge_ztf_night.py
@@ -47,12 +47,6 @@ def main():
 
     print('Processing {}/{}/{}'.format(year, month, day))
 
-    # Uncomment to move old data
-    # input_raw = 'ztf_{}{}/alerts_store/topic=ztf_{}{}{}_programid1/year={}/month={}/day={}'.format(
-    #     year, month, year, month, day, year, month, day)
-    # input_science = 'ztf_{}{}/alerts_store_tmp/year={}/month={}/day={}'.format(
-    #     year, month, year, month, day)
-
     input_raw = '{}/year={}/month={}/day={}'.format(
         args.rawdatapath, year, month, day)
     input_science = '{}/year={}/month={}/day={}'.format(
@@ -67,10 +61,10 @@ def main():
     print('Num partitions before: ', df_raw.rdd.getNumPartitions())
     print('Num partitions after : ', numPart(df_raw))
 
-    df_raw.withColumn('ts_jd', jd_to_datetime(df_raw['candidate.jd']))\
-        .withColumn("year", F.date_format("ts_jd", "yyyy"))\
-        .withColumn("month", F.date_format("ts_jd", "MM"))\
-        .withColumn("day", F.date_format("ts_jd", "dd"))\
+    df_raw.withColumn('timestamp', jd_to_datetime(df_raw['candidate.jd']))\
+        .withColumn("year", F.date_format("timestamp", "yyyy"))\
+        .withColumn("month", F.date_format("timestamp", "MM"))\
+        .withColumn("day", F.date_format("timestamp", "dd"))\
         .coalesce(numPart(df_raw))\
         .write\
         .mode("append") \
@@ -83,10 +77,10 @@ def main():
     print('Num partitions before: ', df_science.rdd.getNumPartitions())
     print('Num partitions after : ', numPart(df_science))
 
-    df_science.withColumn('ts_jd', jd_to_datetime(df_science['candidate.jd']))\
-        .withColumn("year", F.date_format("ts_jd", "yyyy"))\
-        .withColumn("month", F.date_format("ts_jd", "MM"))\
-        .withColumn("day", F.date_format("ts_jd", "dd"))\
+    df_science.withColumn('timestamp', jd_to_datetime(df_science['candidate.jd']))\
+        .withColumn("year", F.date_format("timestamp", "yyyy"))\
+        .withColumn("month", F.date_format("timestamp", "MM"))\
+        .withColumn("day", F.date_format("timestamp", "dd"))\
         .coalesce(numPart(df_science))\
         .write\
         .mode("append") \

--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -72,7 +72,6 @@ def main():
         # it will be available from Spark 3.0 though
         df_decoded = df.select(
             [
-                "topic",
                 from_avro(df["value"], alert_schema_json).alias("decoded")
             ]
         )
@@ -81,7 +80,6 @@ def main():
         f = udf(lambda x: fastavro.reader(io.BytesIO(x)).next(), alert_schema)
         df_decoded = df.select(
             [
-                "topic",
                 f(df['value']).alias("decoded")
             ]
         )


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #376 

## What changes were proposed in this pull request?

The column `topic` is dropped (redundant with the partitioning), and `ts_jd` is renamed in `timestamp`.

## How was this patch tested?
Manually
