### PR TITLE
Install torch only with CPU support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
 
   # Python deps
   - pip install --upgrade pip setuptools wheel
-  - pip install -r requirements.txt
+  - ./install_python_deps.sh 
 
   # Install fink-alert-simulator
   - git clone https://github.com/astrolabsoftware/fink-alert-simulator.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
 
   # Python deps
   - pip install --upgrade pip setuptools wheel
-  - ./install_python_deps.sh 
+  - source install_python_deps.sh 
 
   # Install fink-alert-simulator
   - git clone https://github.com/astrolabsoftware/fink-alert-simulator.git

--- a/install_python_deps.sh
+++ b/install_python_deps.sh
@@ -1,0 +1,9 @@
+#!bin/bash
+
+set -e
+
+# Dependencies
+pip install requirements.txt
+
+# Installation of torch without GPU support (lighter)
+pip install torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html

--- a/install_python_deps.sh
+++ b/install_python_deps.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Dependencies
-pip install requirements.txt
+pip install -r requirements.txt
 
 # Installation of torch without GPU support (lighter)
 pip install torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,12 @@ fink_filters
 fink_science>=0.3.0
 scipy
 scikit-learn
+
+# microlensing
 -e git://github.com/dgodinez77/LIA.git#egg=LIA
+
+# supernnova
 supernnova
-torch
 h5py
 natsort
 colorama


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #397 

## What changes were proposed in this pull request?

This PR adds: 
- installation of torch with CPU support only (to reduce image size since we do not need GPU)
- a wrapper to install all python deps at once `install_python_deps.sh`

## How was this patch tested?

CI
