### PR TITLE
[HBase] Scan along both time and objectId axes

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -324,6 +324,18 @@ elif [[ $service == "science_archival" ]]; then
   ${SAVE_SCIENCE_DB_CATALOG_ONLY} \
   -night ${NIGHT} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
+elif [[ $service == "index_archival" ]]; then
+  # Read configuration for hbase
+  source ${FINK_HOME}/conf/fink.conf.hbase
+  spark-submit --master ${SPARK_MASTER} \
+  --packages ${FINK_PACKAGES} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
+  ${FINK_HOME}/bin/index_archival.py ${HELP_ON_SERVICE} \
+  -science_db_name ${SCIENCE_DB_NAME} \
+  -science_db_catalog ${SCIENCE_DB_CATALOG} \
+  ${SAVE_SCIENCE_DB_CATALOG_ONLY} \
+  -night ${NIGHT} \
+  -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "check_science_portal" ]]; then
   # Read configuration for hbase
   source ${FINK_HOME}/conf/fink.conf.hbase

--- a/bin/fink
+++ b/bin/fink
@@ -337,7 +337,6 @@ elif [[ $service == "index_archival" ]]; then
   ${FINK_HOME}/bin/index_archival.py ${HELP_ON_SERVICE} \
   -science_db_name ${SCIENCE_DB_NAME} \
   -science_db_catalog ${SCIENCE_DB_CATALOG} \
-  ${SAVE_SCIENCE_DB_CATALOG_ONLY} \
   -night ${NIGHT} \
   -index_table ${INDEXTABLE} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}

--- a/bin/fink
+++ b/bin/fink
@@ -106,6 +106,10 @@ while [ "$#" -gt 0 ]; do
       NIGHT="$2"
       shift 2
       ;;
+    --index_table)
+      INDEXTABLE="$2"
+      shift 2
+      ;;
     --exit_after)
         EXIT_AFTER="-exit_after $2"
         shift 2
@@ -335,6 +339,7 @@ elif [[ $service == "index_archival" ]]; then
   -science_db_catalog ${SCIENCE_DB_CATALOG} \
   ${SAVE_SCIENCE_DB_CATALOG_ONLY} \
   -night ${NIGHT} \
+  -index_table ${INDEXTABLE} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "check_science_portal" ]]; then
   # Read configuration for hbase

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -103,7 +103,7 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   # merge and clean data
   fink start merge_and_clean -c conf/fink.conf.travis --night "20190903"
 
-  fink start science_archival -c $conf
+  fink start science_archival -c $conf --night 20190903
 
   fink start check_science_portal -c $conf
 fi

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -104,6 +104,10 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   fink start merge_and_clean -c conf/fink.conf.travis --night "20190903"
 
   fink start science_archival -c $conf --night 20190903
+  fink start index_archival -c $conf --night 20190903 --index_table jd_objectId
+  fink start index_archival -c $conf --night 20190903 --index_table pixel_jd
+  fink start index_archival -c $conf --night 20190903 --index_table class_jd_objectId
+  fink start index_archival -c $conf --night 20190903 --index_table upper_objectId_jd
 
   fink start check_science_portal -c $conf
 fi

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -115,7 +115,21 @@ def main():
             ] + common_cols
         )
     elif columns[0] == 'class':
-        df_index = df.withColumn('class', extract_fink_classification(df['cdsxmatch'], df['roid'], df['mulens_class_1'], df['mulens_class_2'], df['snn_snia_vs_nonia'], df['snn_sn_vs_all'])).select(
+        df_index = df.withColumn(
+            'class',
+            extract_fink_classification(
+                df['cdsxmatch'],
+                df['roid'],
+                df['mulens_class_1'],
+                df['mulens_class_2'],
+                df['snn_snia_vs_nonia'],
+                df['snn_sn_vs_all'],
+                df['rfscore'],
+                df['ndethist'],
+                df['drb'],
+                df['classtar']
+            )
+        ).select(
             [
                 concat_ws('_', *names).alias(index_row_key_name)
             ] + common_cols

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -60,7 +60,7 @@ def main():
     inspect_application(logger)
 
     # Push data monthly
-    path = 'ztf_alerts/science_reprocessed/year={}/month={}/day={}'.format(
+    path = 'ztf_alerts/science/year={}/month={}/day={}'.format(
         args.night[:4],
         args.night[4:6],
         args.night[6:8]

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+# Copyright 2020 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Push science data to the science portal (HBase table)
+
+1. Use the Alert data that is stored in the Science TMP database (Parquet)
+2. Extract relevant information from alerts
+3. Construct HBase catalog
+4. Push data (single shot)
+"""
+from pyspark.sql.functions import lit, concat_ws, col
+
+import argparse
+import time
+import json
+
+from fink_broker import __version__ as fbvsn
+from fink_broker.parser import getargs
+from fink_broker.sparkUtils import init_sparksession, load_parquet_files
+
+from fink_broker.hbaseUtils import construct_hbase_catalog_from_flatten_schema
+from fink_broker.hbaseUtils import load_science_portal_column_names
+from fink_broker.hbaseUtils import assign_column_family_names
+from fink_broker.hbaseUtils import attach_rowkey
+from fink_broker.hbaseUtils import construct_schema_row
+from fink_broker.science import ang2pix, extract_fink_classification
+
+from fink_broker.loggingUtils import get_fink_logger, inspect_application
+
+from fink_science import __version__ as fsvsn
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = getargs(parser)
+
+    # Initialise Spark session
+    spark = init_sparksession(
+        name="index_archival_{}".format(args.night),
+        shuffle_partitions=2
+    )
+
+    # The level here should be controlled by an argument.
+    logger = get_fink_logger(spark.sparkContext.appName, args.log_level)
+
+    # debug statements
+    inspect_application(logger)
+
+    # Push data monthly
+    path = 'ztf_alerts/science_reprocessed/year={}/month={}'.format(
+        args.night[:4],
+        args.night[4:6],
+    )
+    df = load_parquet_files(path)
+
+    # Drop partitioning columns
+    df = df.drop('year').drop('month').drop('day')
+
+    # Load column names to use in the science portal
+    cols_i, cols_d, cols_b = load_science_portal_column_names()
+
+    # Assign each column to a specific column family
+    cf = assign_column_family_names(df, cols_i, cols_d, cols_b)
+
+    # Restrict the input DataFrame to the subset of wanted columns.
+    df = df.select(cols_i + cols_d + cols_b)
+
+    # Create and attach the rowkey
+    df, row_key_name = attach_rowkey(df)
+
+    # construct the index view
+    index_row_key_name = args.index_name
+    columns = index_row_key_name.split('_')
+    index_name = '.' + columns[0] # = 'jd'
+
+    if columns[0] == 'pixel':
+        df_index = df.withColumn('pixel', ang2pix(df['ra'], df['dec'], lit(131072))).select(
+            [
+                concat_ws('_', col('pixel'), col(columns[1])).alias(index_row_key_name),
+                'objectId',
+                'ra', 'dec', 'jd', 'cdsxmatch', 'ndethist',
+                'roid', 'mulens_class_1',
+                'mulens_class_2', 'snn_snia_vs_nonia',
+                'snn_sn_vs_all', 'rfscore',
+            ]
+        )
+    elif columns[0] == 'class':
+        df_index = df.withColumn('class', extract_fink_classification(cdsxmatch, roid, mulens_class_1, mulens_class_2, snn_snia_vs_nonia, snn_sn_vs_all)).select(
+            [
+                concat_ws('_', col('class'), col(columns[1])).alias(index_row_key_name),
+                'objectId',
+                'ra', 'dec', 'jd', 'cdsxmatch', 'ndethist',
+                'roid', 'mulens_class_1',
+                'mulens_class_2', 'snn_snia_vs_nonia',
+                'snn_sn_vs_all', 'rfscore',
+            ]
+        )
+    else:
+        df_index = df.select(
+            [
+                concat_ws('_', df[columns[0]], df[columns[1]]).alias(index_row_key_name),
+                'objectId',
+                'ra', 'dec', 'jd', 'cdsxmatch', 'ndethist',
+                'roid', 'mulens_class_1',
+                'mulens_class_2', 'snn_snia_vs_nonia',
+                'snn_sn_vs_all', 'rfscore'
+            ]
+        )
+
+    # construct the time catalog
+    hbcatalog_index = construct_hbase_catalog_from_flatten_schema(
+        df_index.schema, args.science_db_name + index_name, rowkeyname=index_row_key_name, cf=cf)
+
+    # Push index table
+    df_index.write\
+        .options(catalog=hbcatalog_index, newtable=50)\
+        .format("org.apache.spark.sql.execution.datasources.hbase")\
+        .save()
+
+    # Construct the schema row - inplace replacement
+    schema_row_key_name = 'schema_version'
+    df_index = df_index.withColumnRenamed(index_row_key_name, schema_row_key_name)
+
+    df_index_schema = construct_schema_row(
+        df_index,
+        rowkeyname=schema_row_key_name,
+        version='schema_{}_{}'.format(fbvsn, fsvsn))
+
+    # construct the hbase catalog for the schema
+    hbcatalog_index_schema = construct_hbase_catalog_from_flatten_schema(
+        df_index_schema.schema,
+        args.science_db_name + index_name,
+        rowkeyname=schema_row_key_name,
+        cf=cf)
+
+    # Push the data using the shc connector
+    df_index_schema.write\
+        .options(catalog=hbcatalog_index_schema, newtable=50)\
+        .format("org.apache.spark.sql.execution.datasources.hbase")\
+        .save()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/science_archival.py
+++ b/bin/science_archival.py
@@ -92,11 +92,11 @@ def main():
     # https://stackoverflow.com/questions/56073332/why-hbase-client-put-object-expecting-at-least-a-column-to-be-added-before-subm
     df_time = df.select(
         [
-            concat_ws('_', lit('t'), df['jd'], df['objectId']).alias(time_row_key_name),
+            concat_ws('_', df['jd'], df['objectId']).alias(time_row_key_name),
             'objectId',
             'ra', 'dec', 'jd', 'cdsxmatch', 'ndethist',
             'roid', 'mulens_class_1',
-            'mulens_class_1', 'snn_snia_vs_nonia',
+            'mulens_class_2', 'snn_snia_vs_nonia',
             'snn_sn_vs_all', 'rfscore'
         ]
     )

--- a/conf/fink.conf.hbase
+++ b/conf/fink.conf.hbase
@@ -20,7 +20,7 @@
 LOG_LEVEL=INFO
 
 # The name of the HBase table (must exist)
-SCIENCE_DB_NAME="test_portal.4"
+SCIENCE_DB_NAME="test_portal"
 
 # For debug - careful false/true must be small letters
 SAVE_SCIENCE_DB_CATALOG_ONLY=false

--- a/conf/fink.conf.hbase
+++ b/conf/fink.conf.hbase
@@ -19,11 +19,8 @@
 # Note that for Spark, the level is set to WARN (see log4j.properties)
 LOG_LEVEL=INFO
 
-# Path to the night to archive
-NIGHT='20190903'
-
 # The name of the HBase table (must exist)
-SCIENCE_DB_NAME="test_portal"
+SCIENCE_DB_NAME="test_portal.4"
 
 # For debug - careful false/true must be small letters
 SAVE_SCIENCE_DB_CATALOG_ONLY=false

--- a/conf/install_hbase.sh
+++ b/conf/install_hbase.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 set -e
 
-HBASE_VERSION=2.2.4
+HBASE_VERSION=2.2.6
 
 wget http://www-us.apache.org/dist/hbase/${HBASE_VERSION}/hbase-${HBASE_VERSION}-bin.tar.gz
 tar -zxvf hbase-${HBASE_VERSION}-bin.tar.gz

--- a/fink_broker/hbaseUtils.py
+++ b/fink_broker/hbaseUtils.py
@@ -242,7 +242,7 @@ def construct_hbase_catalog_from_flatten_schema(
         if type(column["type"]) == dict:
             column["type"] = "string" # column["type"]["type"]
 
-        if type(column["type"]) == 'timestamp':
+        if column["type"] == 'timestamp':
             column["type"] = "string" # column["type"]["type"]
 
         if column["name"] == rowkeyname:

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -240,6 +240,12 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         data on HBase. Default is False.
         [SAVE_SCIENCE_DB_CATALOG_ONLY]
         """)
+    parser.add_argument(
+        '-index_table', type=str, default='',
+        help="""
+        Name of the rowkey for index table
+        [INDEXTABLE]
+        """)
     args = parser.parse_args(None)
     return args
 

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -182,8 +182,13 @@ def apply_science_modules(df: DataFrame, logger: Logger) -> DataFrame:
     return df
 
 @pandas_udf(StringType(), PandasUDFType.SCALAR)
-def extract_fink_classification(cdsxmatch, roid, mulens_class_1, mulens_class_2, snn_snia_vs_nonia, snn_sn_vs_all):
+def extract_fink_classification(
+        cdsxmatch, roid, mulens_class_1, mulens_class_2,
+        snn_snia_vs_nonia, snn_sn_vs_all, rfscore,
+        ndethist, drb, classtar):
     """ Extract the classification of an alert based on module outputs
+
+    See https://arxiv.org/abs/2009.10185 for more information
     """
     classification = pd.Series(['Unknown'] * len(cdsxmatch))
     ambiguity = pd.Series([0] * len(cdsxmatch))

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -203,6 +203,7 @@ def extract_fink_classification(
     low_ndethist = ndethist.astype(int) < 400
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
+    early_ndethist = ndethist.astype(int) <= 20
 
     list_simbad_galaxies = [
         "galaxy",
@@ -226,7 +227,7 @@ def extract_fink_classification(
         ["Unknown", "Candidate_SN*", "SN", "Transient"] + list_simbad_galaxies
 
     f_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & low_ndethist & high_drb & high_classtar
-    f_sn_early = (active_learn) & f_sn
+    f_sn_early = early_ndethist & active_learn & f_sn
 
     # Solar System Objects
     f_roid = roid.astype(int).isin([2, 3])

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ fink_filters
 fink_science>=0.3.0
 scipy
 scikit-learn
+healpy
 
 # microlensing
 -e git://github.com/dgodinez77/LIA.git#egg=LIA


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #401 

## What changes were proposed in this pull request?

This PR adds new rows in the HBase table serving the science portal to allow scanning efficiently along both `objectId` and `time` (jd). The additional cost to add the time axis is minimal as each row has only one column (compared to the hundreds columns for the objectid axis).

## How was this patch tested?

On the cloud directly