### PR TITLE
Push Early SN candidates to TNS (nightly)

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -114,6 +114,10 @@ while [ "$#" -gt 0 ]; do
       TNS_FOLDER="$2"
       shift 2
       ;;
+    --tns_sandbox)
+      TNS_SANDBOX=true
+      shift 1
+      ;;
     --exit_after)
         EXIT_AFTER="-exit_after $2"
         shift 2
@@ -345,13 +349,19 @@ elif [[ $service == "index_archival" ]]; then
   -index_table ${INDEXTABLE} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "push_to_tns" ]]; then
-  # Read configuration for hbase
+  # Check if we just need to test
+  if [[ $TNS_SANDBOX = true ]] ; then
+    TNS_SANDBOX="--tns_sandbox"
+  else
+    TNS_SANDBOX=""
+  fi
+
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \
   --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
   ${FINK_HOME}/bin/push_to_tns.py ${HELP_ON_SERVICE} \
   -night ${NIGHT} \
-  -tns_folder ${TNS_FOLDER} \
+  -tns_folder ${TNS_FOLDER} ${TNS_SANDBOX} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "check_science_portal" ]]; then
   # Read configuration for hbase

--- a/bin/fink
+++ b/bin/fink
@@ -110,6 +110,10 @@ while [ "$#" -gt 0 ]; do
       INDEXTABLE="$2"
       shift 2
       ;;
+    --tns_folder)
+      TNS_FOLDER="$2"
+      shift 2
+      ;;
     --exit_after)
         EXIT_AFTER="-exit_after $2"
         shift 2
@@ -339,6 +343,15 @@ elif [[ $service == "index_archival" ]]; then
   -science_db_catalog ${SCIENCE_DB_CATALOG} \
   -night ${NIGHT} \
   -index_table ${INDEXTABLE} \
+  -log_level ${LOG_LEVEL} ${EXIT_AFTER}
+elif [[ $service == "push_to_tns" ]]; then
+  # Read configuration for hbase
+  spark-submit --master ${SPARK_MASTER} \
+  --packages ${FINK_PACKAGES} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
+  ${FINK_HOME}/bin/push_to_tns.py ${HELP_ON_SERVICE} \
+  -night ${NIGHT} \
+  -tns_folder ${TNS_FOLDER} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "check_science_portal" ]]; then
   # Read configuration for hbase

--- a/bin/push_to_tns.py
+++ b/bin/push_to_tns.py
@@ -44,7 +44,7 @@ def main():
     inspect_application(logger)
 
     # Push data monthly
-    path = 'ztf_alerts/science/year={}/month={}/day={}'.format(
+    path = 'ztf_alerts/science_reprocessed/year={}/month={}/day={}'.format(
         args.night[:4],
         args.night[4:6],
         args.night[6:8]

--- a/bin/push_to_tns.py
+++ b/bin/push_to_tns.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# Copyright 2020 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Push early SN candidates to TNS
+"""
+from fink_broker.parser import getargs
+from fink_broker.sparkUtils import init_sparksession, load_parquet_files
+from fink_broker.science import extract_fink_classification
+from fink_broker.loggingUtils import get_fink_logger, inspect_application
+
+from fink_tns.utils import read_past_ids, retrieve_groupid
+from fink_tns.report import extract_discovery_photometry, build_report
+from fink_tns.report import save_logs_and_return_json_report, send_json_report
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = getargs(parser)
+
+    # Initialise Spark session
+    spark = init_sparksession(
+        name="TNS_report_{}".format(args.night),
+        shuffle_partitions=2
+    )
+
+    # The level here should be controlled by an argument.
+    logger = get_fink_logger(spark.sparkContext.appName, args.log_level)
+
+    # debug statements
+    inspect_application(logger)
+
+    # Push data monthly
+    path = 'ztf_alerts/science/year={}/month={}/day={}'.format(
+        args.night[:4],
+        args.night[4:6],
+        args.night[6:8]
+    )
+    df = load_parquet_files(path)
+
+    sandbox = True
+    if not sandbox:
+        print("WARNING: submitting to real (not sandbox) TNS website")
+
+    if sandbox:
+        url_tns_api = "https://sandbox-tns.weizmann.ac.il/api"
+        with open('sandbox-tns_api.key') as f:
+            # remove line break...
+            key = f.read().replace('\n', '')
+    else:
+        url_tns_api = "https://wis-tns.weizmann.ac.il/api"
+        with open('tns_api.key') as f:
+            # remove line break...
+            key = f.read().replace('\n', '')
+
+    cols = [
+        'cdsxmatch', 'roid', 'mulens.class_1', 'mulens.class_2',
+        'snn_snia_vs_nonia', 'snn_sn_vs_all', 'rfscore',
+        'candidate.ndethist', 'candidate.drb', 'candidate.classtar'
+    ]
+    df = df.withColumn('class', extract_fink_classification(*cols))
+
+    pdf = df\
+        .filter(df['class'] == 'Early SN candidate')\
+        .filter(df['candidate.ndethist'] <= 20)\
+        .toPandas()
+
+    pdf_unique = pdf.groupby('objectId')[pdf.columns].min()
+    print("{} new alerts".format(len(pdf)))
+    print("{} new sources".format(len(pdf_unique)))
+    pdf = pdf_unique
+
+    ids = []
+    report = {"at_report": {}}
+    check_tns = False
+    for index, row in enumerate(pdf.iterrows()):
+        alert = row[1]
+        past_ids = read_past_ids('tns_logs')
+        if alert['objectId'] in past_ids.values:
+            print('{} already sent!'.format(alert['objectId']))
+            continue
+        if check_tns:
+            groupid = retrieve_groupid(key, alert['objectId'])
+            if groupid > 0:
+                print("{} already reported by {}".format(
+                    alert['objectId'],
+                    groupid
+                ))
+            else:
+                print('New report for object {}'.format(alert['objectId']))
+        photometry, non_detection = extract_discovery_photometry(alert)
+        report['at_report']["{}".format(index)] = build_report(
+            alert,
+            photometry,
+            non_detection
+        )
+        ids.append(alert['objectId'])
+    print('new objects: ', ids)
+
+    if len(ids) != 0:
+        json_report = save_logs_and_return_json_report(
+            name='{}{}{}'.format(
+                args.night[:4],
+                args.night[4:6],
+                args.night[6:8]
+            ),
+            folder='tns_logs',
+            ids=ids,
+            report=report
+        )
+        r = send_json_report(key, url_tns_api, json_report)
+        print(r.json())
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/push_to_tns.py
+++ b/bin/push_to_tns.py
@@ -16,6 +16,8 @@
 
 """Push early SN candidates to TNS
 """
+import argparse
+
 from fink_broker.parser import getargs
 from fink_broker.sparkUtils import init_sparksession, load_parquet_files
 from fink_broker.science import extract_fink_classification

--- a/bin/push_to_tns.py
+++ b/bin/push_to_tns.py
@@ -51,11 +51,10 @@ def main():
     )
     df = load_parquet_files(path)
 
-    sandbox = True
-    if not sandbox:
+    if not args.tns_sandbox:
         print("WARNING: submitting to real (not sandbox) TNS website")
 
-    if sandbox:
+    if args.tns_sandbox:
         url_tns_api = "https://sandbox-tns.weizmann.ac.il/api"
         with open('{}/sandbox-tns_api.key'.format(args.tns_folder)) as f:
             # remove line break...

--- a/bin/push_to_tns.py
+++ b/bin/push_to_tns.py
@@ -55,12 +55,12 @@ def main():
 
     if sandbox:
         url_tns_api = "https://sandbox-tns.weizmann.ac.il/api"
-        with open('sandbox-tns_api.key') as f:
+        with open('{}/sandbox-tns_api.key'.format(args.tns_folder)) as f:
             # remove line break...
             key = f.read().replace('\n', '')
     else:
         url_tns_api = "https://wis-tns.weizmann.ac.il/api"
-        with open('tns_api.key') as f:
+        with open('{}/tns_api.key'.format(args.tns_folder)) as f:
             # remove line break...
             key = f.read().replace('\n', '')
 
@@ -86,7 +86,7 @@ def main():
     check_tns = False
     for index, row in enumerate(pdf.iterrows()):
         alert = row[1]
-        past_ids = read_past_ids('tns_logs')
+        past_ids = read_past_ids(args.tns_folder)
         if alert['objectId'] in past_ids.values:
             print('{} already sent!'.format(alert['objectId']))
             continue
@@ -115,7 +115,7 @@ def main():
                 args.night[4:6],
                 args.night[6:8]
             ),
-            folder='tns_logs',
+            folder=args.tns_folder,
             ids=ids,
             report=report
         )

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -252,6 +252,12 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         Folder to store logs and keys for TNS submission
         [TNS_FOLDER]
         """)
+    parser.add_argument(
+        '--tns_sandbox', action='store_true',
+        help="""
+        If True, push to TNS sandbox. Default is False.
+        [TNS_SANDBOX]
+        """)
     args = parser.parse_args(None)
     return args
 

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -246,6 +246,12 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         Name of the rowkey for index table
         [INDEXTABLE]
         """)
+    parser.add_argument(
+        '-tns_folder', type=str, default='',
+        help="""
+        Folder to store logs and keys for TNS submission
+        [TNS_FOLDER]
+        """)
     args = parser.parse_args(None)
     return args
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ fink_science>=0.3.0
 scipy
 scikit-learn
 healpy
+fink-tns
 
 # microlensing
 -e git://github.com/dgodinez77/LIA.git#egg=LIA


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #403 

## What changes were proposed in this pull request?

This PR introduces a new script to push Early SN candidates to TNS. The script is ran once after each night. By default, the version pushed is using the `sandbox` area: user has to manually switch to the real website. 

Each night, we record on disk the `objectId` that were pushed to avoid re-pushing them on a later time.

To run, this script needs the API key (sandbox or real), that are not available in this repo.

## How was this patch tested?

Manually