### PR TITLE
Add new script to automatically save schema

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -388,6 +388,12 @@ elif [[ $service == "distribution_test" ]]; then
   -distribution_servers ${DISTRIBUTION_SERVERS} \
   -distribution_topic ${DISTRIBUTION_TOPIC} \
   -distribution_schema ${DISTRIBUTION_SCHEMA} -log_level ${LOG_LEVEL}
+elif [[ $service == "save_schema" ]]; then
+  spark-submit --master ${SPARK_MASTER} \
+  --packages ${FINK_PACKAGES} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
+  ${FINK_HOME}/bin/save_distribution_schema.py ${HELP_ON_SERVICE} ${EXIT_AFTER} \
+  -night ${NIGHT} -log_level ${LOG_LEVEL}
 else
   # In case you give an unknown service
   echo "unknown service: $service" >&2

--- a/bin/save_distribution_schema.py
+++ b/bin/save_distribution_schema.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2019 AstroLab Software
-# Author: Abhishek Chauhan, Julien Peloton
+# Copyright 2020 AstroLab Software
+# Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bin/save_distribution_schema.py
+++ b/bin/save_distribution_schema.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# Copyright 2019 AstroLab Software
+# Author: Abhishek Chauhan, Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Save distribution schema on disk
+"""
+from pyspark.sql.functions import lit
+
+import argparse
+from time import time
+import subprocess
+import glob
+import json
+
+from fink_broker.parser import getargs
+from fink_broker.sparkUtils import init_sparksession, load_parquet_files
+from fink_broker.distributionUtils import get_kafka_df
+from fink_broker.avroUtils import readschemafromavrofile
+from fink_broker.loggingUtils import get_fink_logger, inspect_application
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = getargs(parser)
+
+    # Initialise Spark session
+    spark = init_sparksession(name="save_schema_{}".format(args.night), shuffle_partitions=2)
+
+    # The level here should be controlled by an argument.
+    logger = get_fink_logger(spark.sparkContext.appName, args.log_level)
+
+    # debug statements
+    inspect_application(logger)
+
+    # Connect to the TMP science database
+    year = args.night[:4]
+    month = args.night[4:6]
+    day = args.night[6:8]
+
+    print('Processing {}/{}/{}'.format(year, month, day))
+
+    input_science = 'current/science/year={}/month={}/day={}'.format(
+        year, month, day)
+    df = load_parquet_files(input_science)
+
+    # Drop partitioning columns
+    df = df.drop('year').drop('month').drop('day')
+
+    # Cast fields to ease the distribution
+    cnames = df.columns
+    cnames[cnames.index('timestamp')] = 'cast(timestamp as string) as timestamp'
+    cnames[cnames.index('cutoutScience')] = 'struct(cutoutScience.*) as cutoutScience'
+    cnames[cnames.index('cutoutTemplate')] = 'struct(cutoutTemplate.*) as cutoutTemplate'
+    cnames[cnames.index('cutoutDifference')] = 'struct(cutoutDifference.*) as cutoutDifference'
+    cnames[cnames.index('mulens')] = 'struct(mulens.*) as mulens'
+    cnames[cnames.index('prv_candidates')] = 'explode(array(prv_candidates)) as prv_candidates'
+    cnames[cnames.index('candidate')] = 'struct(candidate.*) as candidate'
+
+    df_kafka = df.selectExpr(cnames)
+
+    # # Get the DataFrame for publishing to Kafka (avro serialized)
+    # df_kafka = get_kafka_df(df, '')
+
+    path_for_avro = 'new_schema_{}.avro'.format(time())
+    df_kafka.limit(1).write.format("avro").save(path_for_avro)
+
+    # retrieve data on local disk
+    subprocess.run(["hdfs", "dfs", '-get', path_for_avro])
+
+    # Read the avro schema from .avro file
+    avro_file = glob.glob(path_for_avro + "/part*")[0]
+    avro_schema = readschemafromavrofile(avro_file)
+
+    # Write the schema to a file for decoding Kafka messages
+    with open('schemas/{}'.format(path_for_avro.replace('.avro', '.avsc')), 'w') as f:
+        json.dump(avro_schema, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #350

## What changes were proposed in this pull request?

This PR introduces a new command to automatically save an Avro schema from processed data and suitable for redistributing the alerts:

```bash
# Extract schema based on the processed night 2020/12/02
fink start save_schema -c conf_cluster/fink.conf.ztf_nomonitoring --night 20201202
```

The schema needs then to be propagated to `fink-client` in order to poll new alerts.

## How was this patch tested?

On data.