### PR TITLE
New index table for known SSO

### DIFF
--- a/bin/fink_test
+++ b/bin/fink_test
@@ -106,6 +106,7 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   fink start index_archival -c $conf --night 20190903 --index_table pixel_jd
   fink start index_archival -c $conf --night 20190903 --index_table class_jd_objectId
   fink start index_archival -c $conf --night 20190903 --index_table upper_objectId_jd
+  fink start index_archival -c $conf --night 20190903 --index_table ssnamenr_jd
 
   fink start check_science_portal -c $conf
 

--- a/scheduler/database_service.sh
+++ b/scheduler/database_service.sh
@@ -26,6 +26,7 @@ if [[ $? == 0 ]]; then
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table pixel_jd > ${FINK_HOME}/broker_logs/index_pixel_jd_${NIGHT}.log 2>&1
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table class_jd_objectId > ${FINK_HOME}/broker_logs/index_class_jd_objectId_${NIGHT}.log 2>&1
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table upper_objectId_jd > ${FINK_HOME}/broker_logs/index_upper_objectId_jd_${NIGHT}.log 2>&1
+    fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table ssnamenr_jd > ${FINK_HOME}/broker_logs/index_ssnamenr_jd_${NIGHT}.log 2>&1
 
     echo "Push TNS candidates"
     fink start push_to_tns -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --tns_folder ${FINK_HOME}/tns_logs > ${FINK_HOME}/broker_logs/tns_${NIGHT}.log 2>&1


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #412 

## What changes were proposed in this pull request?

This PR adds a new index table to handle Solar System Objects. We push only candidates that have a counterpart in the MPC database. 

We recently detected a bug in the SSO tagging (see https://github.com/astrolabsoftware/fink-science/issues/85). Hence, the computation of the table does not rely on the `roid` field, but uses a series of cuts (that are also now present in fink-science). In order to use again `roid`, we would have to recompute all science data from the raw data... (so we use the fix for the moment).

## How was this patch tested?

CI
