### PR TITLE
Update classification for SSO and microlensing

### DIFF
--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -248,7 +248,8 @@ def extract_fink_classification(
     f_kn = f_kn & early_ndethist & cdsxmatch.isin(keep_cds)
 
     # Solar System Objects
-    f_roid = roid.astype(int).isin([2, 3])
+    f_roid_2 = roid.astype(int) == 2
+    f_roid_3 = roid.astype(int) == 3
 
     # Simbad xmatch
     f_simbad = ~cdsxmatch.isin(['Unknown', 'Transient', 'Fail'])
@@ -257,7 +258,8 @@ def extract_fink_classification(
     classification.mask(f_sn.values, 'SN candidate', inplace=True)
     classification.mask(f_sn_early.values, 'Early SN candidate', inplace=True)
     classification.mask(f_kn.values, 'Kilonova candidate', inplace=True)
-    classification.mask(f_roid.values, 'Solar System', inplace=True)
+    classification.mask(f_roid_2.values, 'Solar System candidate', inplace=True)
+    classification.mask(f_roid_3.values, 'Solar System MPC', inplace=True)
 
     # If several flags are up, we cannot rely on the classification
     ambiguity[f_mulens.values] += 1

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -264,7 +264,8 @@ def extract_fink_classification(
     # If several flags are up, we cannot rely on the classification
     ambiguity[f_mulens.values] += 1
     ambiguity[f_sn.values] += 1
-    ambiguity[f_roid.values] += 1
+    ambiguity[f_roid_2.values] += 1
+    ambiguity[f_roid_3.values] += 1
     f_ambiguity = ambiguity > 1
     classification.mask(f_ambiguity.values, 'Ambiguous', inplace=True)
 

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -199,7 +199,8 @@ def extract_fink_classification(
     ambiguity = pd.Series([0] * len(cdsxmatch))
 
     # Microlensing classification
-    f_mulens = (mulens_class_1 == 'ML') & (mulens_class_2 == 'ML')
+    medium_ndethist = ndethist.astype(int) < 100
+    f_mulens = (mulens_class_1 == 'ML') & (mulens_class_2 == 'ML') & medium_ndethist
 
     # SN Ia
     snn1 = snn_snia_vs_nonia.astype(float) > 0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ healpy
 fink-tns
 
 # microlensing
--e git://github.com/dgodinez77/LIA.git@FINK
+-e git://github.com/dgodinez77/LIA.git@FINK#egg=LIA
 
 # supernnova
 supernnova

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ healpy
 fink-tns
 
 # microlensing
--e git://github.com/dgodinez77/LIA.git#egg=LIA
+-e git://github.com/dgodinez77/LIA.git@FINK
 
 # supernnova
 supernnova


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #441 & #422 

## What changes were proposed in this pull request?

This PR updates the classification for SSO and microlensing:
- For SSO, it splits the classification into two classes: confirmed SSO in MPC (`Solar System MPC`), and new SSO candidates (`Solar System candidate`)
- For microlensing, it adds a new cut on the length of the history (less than 100 detection at 3 sigma), to get only early candidates (and avoid variable stars).

## How was this patch tested?

Manually