### PR TITLE
Update the  script to push candidates to TNS with  the new header

### DIFF
--- a/bin/push_to_tns.py
+++ b/bin/push_to_tns.py
@@ -53,7 +53,7 @@ def main():
     )
     df = load_parquet_files(path)
 
-    with open('{}/tns_marker.txt') as f:
+    with open('{}/tns_marker.txt'.format(args.tns_folder)) as f:
         tns_marker = f.read().replace('\n', '')
 
     if not args.tns_sandbox:

--- a/bin/push_to_tns.py
+++ b/bin/push_to_tns.py
@@ -53,6 +53,9 @@ def main():
     )
     df = load_parquet_files(path)
 
+    with open('{}/tns_marker.txt') as f:
+        tns_marker = f.read().replace('\n', '')
+
     if not args.tns_sandbox:
         print("WARNING: submitting to real (not sandbox) TNS website")
 
@@ -95,7 +98,7 @@ def main():
             print('{} already sent!'.format(alert['objectId']))
             continue
         if check_tns:
-            groupid = retrieve_groupid(key, alert['objectId'])
+            groupid = retrieve_groupid(key, tns_marker, alert['objectId'])
             if groupid > 0:
                 print("{} already reported by {}".format(
                     alert['objectId'],
@@ -123,7 +126,7 @@ def main():
             ids=ids,
             report=report
         )
-        r = send_json_report(key, url_tns_api, json_report)
+        r = send_json_report(key, url_tns_api, json_report, tns_marker)
         print(r.json())
 
         # post to slack

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ fink_science>=0.3.0
 scipy
 scikit-learn
 healpy
-fink-tns
+fink-tns>=0.6
 
 # microlensing
 -e git://github.com/dgodinez77/LIA.git@FINK#egg=LIA


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #446 

## What changes were proposed in this pull request?

This script update the way we push candidates to TNS by adding the  header. The header must be stored in a text file called `tns_marker.txt`, and available in the `tns_folder` alongside the `api_key` file.

## How was this patch tested?

Manually
