### PR TITLE
Remove incoming duplicate based on candid

### DIFF
--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -102,7 +102,9 @@ def main():
         .withColumn("day", date_format("timestamp", "dd"))
 
     # Append new rows every `tinterval` seconds
+    # and drop duplicates see fink-broker/issues/443
     countquery_tmp = df_partitionedby\
+        .dropDuplicates(["candid"])\
         .writeStream\
         .outputMode("append") \
         .format("parquet") \


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): #443 

## What changes were proposed in this pull request?

This PR adds a step in stream2raw to remove alerts with identical `candid`. See #443 for more details.

## How was this patch tested?

In the cloud (acted as hotfix for weeks)
