### PR TITLE
Reduce the time frame to classify alerts as SN

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 **IMPORTANT: Please create an issue first before opening a Pull Request.**
-Linked to issue(s): _put link_
+Linked to issue(s): Closes _put link_
 
 ## What changes were proposed in this pull request?
 

--- a/bin/distribute.py
+++ b/bin/distribute.py
@@ -88,6 +88,10 @@ def main():
     for colname in to_expand:
         df = concat_col(df, colname, prefix=prefix)
 
+    # quick fix for https://github.com/astrolabsoftware/fink-broker/issues/457
+    for colname in to_expand:
+        df = df.withColumnRenamed('c' + colname, 'c' + colname + 'c')
+
     broker_list = args.distribution_servers
     for userfilter in userfilters:
         # The topic name is the filter name

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -285,11 +285,15 @@ def extract_fink_classification(
     high_knscore = knscore_.astype(float) > 0.5
 
     # Others
+    # Note jdstarthist is not really reliable...
+    # see https://github.com/astrolabsoftware/fink-science-portal/issues/163
+    # KN & SN candidate still affected (not Early SN Ia candidate)
+    # Perhaps something to report to ZTF
     sn_history = jd.astype(float) - jdstarthist.astype(float) <= 90
+    new_detection = jd.astype(float) - jdstarthist.astype(float) < 20
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
     early_ndethist = ndethist.astype(int) < 20
-    new_detection = jd.astype(float) - jdstarthist.astype(float) < 20
 
     list_simbad_galaxies = [
         "galaxy",
@@ -312,8 +316,9 @@ def extract_fink_classification(
     keep_cds = \
         ["Unknown", "Candidate_SN*", "SN", "Transient", "Fail"] + list_simbad_galaxies
 
-    f_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & sn_history & high_drb & high_classtar
-    f_sn_early = early_ndethist & active_learn & f_sn
+    base_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & high_drb & high_classtar
+    f_sn = base_sn & sn_history
+    f_sn_early = base_sn & early_ndethist & active_learn
 
     # Kilonova
     keep_cds = \

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -285,7 +285,7 @@ def extract_fink_classification(
     high_knscore = knscore_.astype(float) > 0.5
 
     # Others
-    sn_history = jd.astype(float) - jdstarthist.astype(float) <= 21
+    sn_history = jd.astype(float) - jdstarthist.astype(float) <= 90
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
     early_ndethist = ndethist.astype(int) < 20

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -294,6 +294,8 @@ def extract_fink_classification(
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
     early_ndethist = ndethist.astype(int) < 20
+    no_mpc = roid.astype(int) != 3
+    no_first_det = ndethist.astype(int) > 1
 
     list_simbad_galaxies = [
         "galaxy",
@@ -316,7 +318,7 @@ def extract_fink_classification(
     keep_cds = \
         ["Unknown", "Candidate_SN*", "SN", "Transient", "Fail"] + list_simbad_galaxies
 
-    base_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & high_drb & high_classtar
+    base_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & high_drb & high_classtar & no_mpc & no_first_det
     f_sn = base_sn & sn_history
     f_sn_early = base_sn & early_ndethist & active_learn
 

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -285,7 +285,7 @@ def extract_fink_classification(
     high_knscore = knscore_.astype(float) > 0.5
 
     # Others
-    low_ndethist = ndethist.astype(int) < 400
+    sn_history = jd.astype(float) - jdstarthist.astype(float) <= 21
     high_drb = drb.astype(float) > 0.5
     high_classtar = classtar.astype(float) > 0.4
     early_ndethist = ndethist.astype(int) < 20
@@ -312,7 +312,7 @@ def extract_fink_classification(
     keep_cds = \
         ["Unknown", "Candidate_SN*", "SN", "Transient", "Fail"] + list_simbad_galaxies
 
-    f_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & low_ndethist & high_drb & high_classtar
+    f_sn = (snn1 | snn2) & cdsxmatch.isin(keep_cds) & sn_history & high_drb & high_classtar
     f_sn_early = early_ndethist & active_learn & f_sn
 
     # Kilonova


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #455

## What changes were proposed in this pull request?

This PR reduces the time frame to classify an object as SN candidate from `ndethist < 400` to `delta(jd) <= 90`. This will reduce the number of long variables misclassified. Note however that after a period of 90 days, an object cannot be considered as SN candidate. Two options for the future:
- report any official classification (spectro, catalogs, ...)
- use SuperNNova on the full light-curve to give a consolidated score.

## How was this patch tested?

Manually
