### PR TITLE
Create individual index tables for conesearch and xmatch

### DIFF
--- a/bin/fink_test
+++ b/bin/fink_test
@@ -103,8 +103,9 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   # Update science portal
   fink start science_archival -c $conf --night 20190903
   fink start index_archival -c $conf --night 20190903 --index_table jd_objectId
-  fink start index_archival -c $conf --night 20190903 --index_table pixel_jd
-  fink start index_archival -c $conf --night 20190903 --index_table pixels_jd
+  fink start index_archival -c $conf --night 20190903 --index_table pixel128_jd
+  fink start index_archival -c $conf --night 20190903 --index_table pixel4096_jd
+  fink start index_archival -c $conf --night 20190903 --index_table pixel131072_jd
   fink start index_archival -c $conf --night 20190903 --index_table class_jd_objectId
   fink start index_archival -c $conf --night 20190903 --index_table upper_objectId_jd
   fink start index_archival -c $conf --night 20190903 --index_table uppervalid_objectId_jd

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -130,7 +130,7 @@ def main():
         nside = int(columns[0].split('pixel')[1])
 
         df_index = df.withColumn(
-            'pixel',
+            columns[0],
             ang2pix(
                 df['ra'],
                 df['dec'],

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -126,25 +126,20 @@ def main():
         'classtar', 'drb', 'ndethist', 'knscore'
     ]
 
-    if columns[0] == 'pixel':
-        df_index = df.withColumn('pixel', ang2pix(df['ra'], df['dec'], lit(131072))).select(
-            [
-                concat_ws('_', *names).alias(index_row_key_name)
-            ] + common_cols
-        )
-    elif columns[0] == 'pixels':
-        # degree/arcmin/arcsec scale
+    if columns[0].startswith('pixel'):
+        nside = int(columns[0].split('pixel')[1])
+
         df_index = df.withColumn(
-            'pixels',
-            ang2pix_array(
+            'pixel',
+            ang2pix(
                 df['ra'],
                 df['dec'],
-                F.array([lit(128), lit(4096), lit(131072)])
+                lit(nside)
             )
         ).select(
             [
                 concat_ws('_', *names).alias(index_row_key_name)
-            ] + common_cols
+            ] + ['objectId']
         )
     elif columns[0] == 'class':
         df_index = df.withColumn(

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -42,7 +42,7 @@ from fink_broker.hbaseUtils import assign_column_family_names
 from fink_broker.hbaseUtils import attach_rowkey
 from fink_broker.hbaseUtils import construct_schema_row
 from fink_broker.science import extract_fink_classification
-from fink_broker.science import ang2pix, ang2pix_array
+from fink_broker.science import ang2pix
 
 from fink_tns.utils import download_catalog
 

--- a/scheduler/database_service.sh
+++ b/scheduler/database_service.sh
@@ -23,8 +23,9 @@ if [[ $? == 0 ]]; then
 
     echo "Update index tables"
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table jd_objectId > ${FINK_HOME}/broker_logs/index_jd_objectId_${NIGHT}.log 2>&1
-    fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table pixel_jd > ${FINK_HOME}/broker_logs/index_pixel_jd_${NIGHT}.log 2>&1
-    fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table pixels_jd > ${FINK_HOME}/broker_logs/index_pixels_jd_${NIGHT}.log 2>&1
+    fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table pixel128_jd > ${FINK_HOME}/broker_logs/index_pixel128_jd_${NIGHT}.log 2>&1
+    fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table pixel4096_jd > ${FINK_HOME}/broker_logs/index_pixel4096_jd_${NIGHT}.log 2>&1
+    fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table pixel131072_jd > ${FINK_HOME}/broker_logs/index_pixel131072_jd_${NIGHT}.log 2>&1
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table class_jd_objectId > ${FINK_HOME}/broker_logs/index_class_jd_objectId_${NIGHT}.log 2>&1
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table upper_objectId_jd > ${FINK_HOME}/broker_logs/index_upper_objectId_jd_${NIGHT}.log 2>&1
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table ssnamenr_jd > ${FINK_HOME}/broker_logs/index_ssnamenr_jd_${NIGHT}.log 2>&1


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #472 

## What changes were proposed in this pull request?

Add new index tables for conesearch and xmatch (that replace old ones) in the form `pixel_jd` at various NSIDE, and contain only one field `objectId`.

## How was this patch tested?

Manually