### PR TITLE
Renaming fields for Active Learning and kilonova modules

### DIFF
--- a/bin/daily_stats.py
+++ b/bin/daily_stats.py
@@ -127,13 +127,13 @@ def main():
             df_sci['mulens.class_2'],
             df_sci['snn_snia_vs_nonia'],
             df_sci['snn_sn_vs_all'],
-            df_sci['rfscore'],
+            df_sci['rf_snia_vs_nonia'],
             df_sci['candidate.ndethist'],
             df_sci['candidate.drb'],
             df_sci['candidate.classtar'],
             df_sci['candidate.jd'],
             df_sci['candidate.jdstarthist'],
-            df_sci['knscore'],
+            df_sci['rf_kn_vs_nonkn'],
             df_sci['tracklet']
         )
     )

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -143,8 +143,8 @@ def main():
         'cdsxmatch',
         'roid',
         'mulens_class_1', 'mulens_class_2',
-        'snn_snia_vs_nonia', 'snn_sn_vs_all', 'rfscore',
-        'classtar', 'drb', 'ndethist', 'knscore', 'tracklet'
+        'snn_snia_vs_nonia', 'snn_sn_vs_all', 'rf_snia_vs_nonia',
+        'classtar', 'drb', 'ndethist', 'rf_kn_vs_nonkn', 'tracklet'
     ]
 
     if columns[0].startswith('pixel'):
@@ -172,13 +172,13 @@ def main():
                 df['mulens_class_2'],
                 df['snn_snia_vs_nonia'],
                 df['snn_sn_vs_all'],
-                df['rfscore'],
+                df['rf_snia_vs_nonia'],
                 df['ndethist'],
                 df['drb'],
                 df['classtar'],
                 df['jd'],
                 df['jdstarthist'],
-                df['knscore'],
+                df['rf_kn_vs_nonkn'],
                 df['tracklet']
             )
         ).select(

--- a/bin/push_to_tns.py
+++ b/bin/push_to_tns.py
@@ -74,9 +74,9 @@ def main():
 
     cols = [
         'cdsxmatch', 'roid', 'mulens.class_1', 'mulens.class_2',
-        'snn_snia_vs_nonia', 'snn_sn_vs_all', 'rfscore',
+        'snn_snia_vs_nonia', 'snn_sn_vs_all', 'rf_snia_vs_nonia',
         'candidate.ndethist', 'candidate.drb', 'candidate.classtar',
-        'candidate.jd', 'candidate.jdstarthist', 'knscore', 'tracklet'
+        'candidate.jd', 'candidate.jdstarthist', 'rf_kn_vs_nonkn', 'tracklet'
     ]
     df = df.withColumn('class', extract_fink_classification(*cols))
 

--- a/fink_broker/hbaseUtils.py
+++ b/fink_broker/hbaseUtils.py
@@ -1,4 +1,4 @@
-# Copyright 2019 AstroLab Software
+# Copyright 2019-2022 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,14 +59,14 @@ def load_science_portal_column_names():
     # Column family d
     cols_d = [
         'cdsxmatch',
-        'rfscore',
+        'rf_snia_vs_nonia',
         'snn_snia_vs_nonia',
         'snn_sn_vs_all',
         col('mulens.class_1').alias('mulens_class_1'),
         col('mulens.class_2').alias('mulens_class_2'),
         'roid',
         'nalerthist',
-        'knscore',
+        'rf_kn_vs_nonkn',
         'tracklet'
     ]
 

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -1,4 +1,4 @@
-# Copyright 2020 AstroLab Software
+# Copyright 2020-2022 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -185,14 +185,14 @@ def apply_science_modules(df: DataFrame, logger: Logger) -> DataFrame:
     df = df.withColumn('cdsxmatch', cdsxmatch(*colnames))
 
     # Apply level one processor: rfscore
-    logger.info("New processor: rfscore")
+    logger.info("New processor: Active Learning")
 
     # Perform the fit + classification.
     # Note we can omit the model_path argument, and in that case the
     # default model `data/models/default-model.obj` will be used.
     rfscore_args = ['cjd', 'cfid', 'cmagpsf', 'csigmapsf']
     df = df.withColumn(
-        'rfscore',
+        'rf_snia_vs_nonia',
         rfscore_sigmoid_full(*rfscore_args)
     )
 
@@ -253,7 +253,7 @@ def apply_science_modules(df: DataFrame, logger: Logger) -> DataFrame:
     # Apply level one processor: kilonova detection
     logger.info("New processor: kilonova")
     knscore_args = ['cjd', 'cfid', 'cmagpsf', 'csigmapsf']
-    df = df.withColumn('knscore', knscore(*knscore_args))
+    df = df.withColumn('rf_kn_vs_nonkn', knscore(*knscore_args))
 
     # Drop temp columns
     df = df.drop(*expanded)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ codecov
 slackclient
 astropy
 astroquery
-fink_filters>=1.0
+fink_filters>=1.1
 fink_science>=0.3.0
 scipy
 scikit-learn


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #516 

## What changes were proposed in this pull request?

This PR renames `rfscore` and `knscore` into `rf_snia_vs_nonia` and `rf_kn_vs_nonkn` respectively.

## How was this patch tested?

CI