### PR TITLE
Fix broken dependencies to install package from source (git protocol on port 9418 is no longer supported)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ healpy
 fink-tns>=0.6
 
 # microlensing
--e git://github.com/JulienPeloton/LIA.git@4513654b15a0760312eff2661b0fcf4989171ce3#egg=LIA
+-e https://github.com/JulienPeloton/LIA.git@4513654b15a0760312eff2661b0fcf4989171ce3#egg=LIA
 
 # supernnova
 supernnova

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ healpy
 fink-tns>=0.6
 
 # microlensing
--e https://github.com/JulienPeloton/LIA.git@4513654b15a0760312eff2661b0fcf4989171ce3#egg=LIA
+-e git+https://github.com/JulienPeloton/LIA.git@4513654b15a0760312eff2661b0fcf4989171ce3#egg=LIA
 
 # supernnova
 supernnova


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #524 

## What changes were proposed in this pull request?

Fix in `requirements.txt` to install package from source directly

## How was this patch tested?
