### PR TITLE
Add tracklet computation when re-computing science data

### DIFF
--- a/bin/merge_ztf_night.py
+++ b/bin/merge_ztf_night.py
@@ -78,9 +78,17 @@ def main():
     print('Num partitions after : ', npart_after)
 
     # Add tracklet information before merging
-    df_science_ = add_tracklet_information(df_science)
+    df_trck = add_tracklet_information(df_science)
 
-    df_science_.withColumn('timestamp', jd_to_datetime(df_science_['candidate.jd']))\
+    # join back information to the initial dataframe
+    df_science = df_science\
+        .join(
+            F.broadcast(df_trck.select(['candid', 'tracklet'])),
+            on='candid',
+            how='outer'
+        )
+
+    df_science.withColumn('timestamp', jd_to_datetime(df_science['candidate.jd']))\
         .withColumn("year", F.date_format("timestamp", "yyyy"))\
         .withColumn("month", F.date_format("timestamp", "MM"))\
         .withColumn("day", F.date_format("timestamp", "dd"))\

--- a/bin/raw2science_batch.py
+++ b/bin/raw2science_batch.py
@@ -25,7 +25,7 @@ from fink_broker.sparkUtils import init_sparksession
 from fink_broker.filters import apply_user_defined_filter
 from fink_broker.loggingUtils import get_fink_logger, inspect_application
 from fink_broker.partitioning import jd_to_datetime
-
+from fink_broker.tracklet_identification import add_tracklet_information
 from fink_broker.science import apply_science_modules
 
 from fink_science import __version__ as fsvsn
@@ -68,6 +68,9 @@ def main():
 
     # Apply science modules
     df = apply_science_modules(df, logger)
+
+    # Add tracklet information
+    df = add_tracklet_information(df)
 
     # Add librarys versions
     df = df.withColumn('fink_broker_version', F.lit(fbvsn))\

--- a/bin/raw2science_batch.py
+++ b/bin/raw2science_batch.py
@@ -22,7 +22,6 @@ import argparse
 from fink_broker import __version__ as fbvsn
 from fink_broker.parser import getargs
 from fink_broker.sparkUtils import init_sparksession
-from fink_broker.filters import apply_user_defined_filter
 from fink_broker.loggingUtils import get_fink_logger, inspect_application
 from fink_broker.partitioning import jd_to_datetime
 from fink_broker.tracklet_identification import add_tracklet_information

--- a/bin/raw2science_batch.py
+++ b/bin/raw2science_batch.py
@@ -71,6 +71,7 @@ def main():
 
     # Add tracklet information
     df_trck = spark.read.format('parquet').load(input_raw)
+    df_trck = apply_user_defined_filter(df_trck, qualitycuts)
     df_trck = add_tracklet_information(df_trck)
 
     # join back information to the initial dataframe

--- a/bin/raw2science_batch.py
+++ b/bin/raw2science_batch.py
@@ -70,7 +70,16 @@ def main():
     df = apply_science_modules(df, logger)
 
     # Add tracklet information
-    df = add_tracklet_information(df)
+    df_trck = spark.read.format('parquet').load(input_raw)
+    df_trck = add_tracklet_information(df_trck)
+
+    # join back information to the initial dataframe
+    df = df\
+        .join(
+            df_trck.select(['candid', 'tracklet']),
+            on='candid',
+            how='outer'
+        )
 
     # Add librarys versions
     df = df.withColumn('fink_broker_version', F.lit(fbvsn))\

--- a/fink_broker/tracklet_identification.py
+++ b/fink_broker/tracklet_identification.py
@@ -348,13 +348,13 @@ def add_tracklet_information(df: DataFrame) -> DataFrame:
         .select(['candid', 'tracklet'])\
         .filter(F.col('tracklet') != '')
 
-    # join back information to the initial dataframe
-    df_out = df\
-        .join(
-            df_trck.select(['candid', 'tracklet']),
-            on='candid',
-            how='outer'
-        )
+    # # join back information to the initial dataframe
+    # df_out = df\
+    #     .join(
+    #         df_trck.select(['candid', 'tracklet']),
+    #         on='candid',
+    #         how='outer'
+    #     )
 
     return df_out
 

--- a/fink_broker/tracklet_identification.py
+++ b/fink_broker/tracklet_identification.py
@@ -356,7 +356,7 @@ def add_tracklet_information(df: DataFrame) -> DataFrame:
     #         how='outer'
     #     )
 
-    return df_out
+    return df_trck
 
 
 if __name__ == "__main__":

--- a/fink_broker/tracklet_identification.py
+++ b/fink_broker/tracklet_identification.py
@@ -348,14 +348,6 @@ def add_tracklet_information(df: DataFrame) -> DataFrame:
         .select(['candid', 'tracklet'])\
         .filter(F.col('tracklet') != '')
 
-    # # join back information to the initial dataframe
-    # df_out = df\
-    #     .join(
-    #         df_trck.select(['candid', 'tracklet']),
-    #         on='candid',
-    #         how='outer'
-    #     )
-
     return df_trck
 
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #529 

## What changes were proposed in this pull request?

This PR adds the computation of tracklet during the reprocessing step, and speed-up the computation:

- Add `add_tracklet_information` inside the reprocessing
- Use DataFrame `filter` function instead of Pandas UDF to speed-up the filtering
- Broadcast tracklet DataFrame for the join to speed-up

The second point shows an interesting behaviour -- it seems that `apply_user_defined_filter` was using `drb` and not `rb`... If this is true (TBD), we should switch using `drb` and `filter` everywhere.

## How was this patch tested?

Manually and CI
