### PR TITLE
Allow prefixing the Kafka substreams

### DIFF
--- a/bin/distribute.py
+++ b/bin/distribute.py
@@ -98,7 +98,7 @@ def main():
     broker_list = args.distribution_servers
     for userfilter in userfilters:
         # The topic name is the filter name
-        topicname = 'fink_' + userfilter.split('.')[-1] + '_ztf'
+        topicname = args.substream_prefix + userfilter.split('.')[-1] + '_ztf'
 
         # Apply user-defined filter
         df_tmp = apply_user_defined_filter(df, userfilter)

--- a/bin/fink
+++ b/bin/fink
@@ -278,9 +278,8 @@ elif [[ $service == "distribution" ]]; then
   ${FINK_HOME}/bin/distribute.py ${HELP_ON_SERVICE} \
   -online_data_prefix ${ONLINE_DATA_PREFIX} \
   -distribution_servers ${DISTRIBUTION_SERVERS} \
-  -distribution_topic ${DISTRIBUTION_TOPIC} \
   -distribution_schema ${DISTRIBUTION_SCHEMA} \
-  -distribution_rules_xml "${DISTRIBUTION_RULES_XML}" \
+  -substream_prefix ${SUBSTREAM_PREFIX} \
   -tinterval ${FINK_TRIGGER_UPDATE} \
   -night ${NIGHT} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}

--- a/conf/fink.conf.distribution
+++ b/conf/fink.conf.distribution
@@ -56,16 +56,15 @@ kafka_broker_logs[2]="${FINK_HOME}/fink_kafka_logs/broker2"
 # Kafka topic to publish on
 DISTRIBUTION_TOPIC="rrlyr,snialike"
 
+# Kafka topic prefix
+SUBSTREAM_PREFIX="fink_"
+
 # The path where to store the avro distribution schema
 DISTRIBUTION_SCHEMA=${FINK_HOME}/schemas/distribution_schema_0p2.avsc
 
 # Offset for reading the science database
 DISTRIBUTION_OFFSET="latest"
 DISTRIBUTION_OFFSET_FILE=${FINK_HOME}/distribution.offset
-
-# Path of XML rule file for redistribution
-# DISTRIBUTION_RULES_XML=${FINK_HOME}/conf/distribution-rules.xml
-DISTRIBUTION_RULES_XML=''
 
 # Authentication
 # path of jaas files for Authentication

--- a/conf_cluster/fink.conf.distribution_cluster
+++ b/conf_cluster/fink.conf.distribution_cluster
@@ -47,8 +47,8 @@ zk_logs="${FINK_HOME}/fink_kafka_logs/zklogs"
 declare -a kafka_broker_logs
 kafka_broker_logs[0]="${FINK_HOME}/fink_kafka_logs/broker0"
 
-# Kafka topic to publish on
-DISTRIBUTION_TOPIC="rrlyr"
+# Kafka topic prefix
+SUBSTREAM_PREFIX="fink_"
 
 # The path where to store the avro distribution schema
 DISTRIBUTION_SCHEMA=${FINK_HOME}/schemas/distribution_schema_test.avsc
@@ -56,9 +56,6 @@ DISTRIBUTION_SCHEMA=${FINK_HOME}/schemas/distribution_schema_test.avsc
 # Offset for reading the science database
 DISTRIBUTION_OFFSET="earliest"
 DISTRIBUTION_OFFSET_FILE=${FINK_HOME}/distribution.offset
-
-# Path of XML rule file for redistribution
-DISTRIBUTION_RULES_XML=""
 
 # Authentication
 # path of jaas files for Authentication

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -218,6 +218,12 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         If True, push to TNS sandbox. Default is False.
         [TNS_SANDBOX]
         """)
+    parser.add_argument(
+        '-substream_prefix', type=str, default='',
+        help="""
+        Prefix for outgoing substreams
+        [SUBSTREAM_PREFIX]
+        """)
     args = parser.parse_args(None)
     return args
 

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -219,7 +219,7 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         [TNS_SANDBOX]
         """)
     parser.add_argument(
-        '-substream_prefix', type=str, default='',
+        '-substream_prefix', type=str, default='fink_',
         help="""
         Prefix for outgoing substreams
         [SUBSTREAM_PREFIX]


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #549 

## What changes were proposed in this pull request?

One can now define the prefix for outgoing Kafka substreams (it was fixed to `fink_` before).

## How was this patch tested?

CI