### PR TITLE
Deploy microlensing and slope-based KN substreams.

### DIFF
--- a/bin/distribute.py
+++ b/bin/distribute.py
@@ -39,10 +39,10 @@ userfilters = [
     'fink_filters.filter_sso_ztf_candidates.filter.sso_ztf_candidates',
     'fink_filters.filter_sso_fink_candidates.filter.sso_fink_candidates',
     'fink_filters.filter_kn_candidates.filter.kn_candidates',
-    'fink_filters.filter_early_kn_candidates.filter.early_kn_candidates'
+    'fink_filters.filter_early_kn_candidates.filter.early_kn_candidates',
+    'fink_filters.filter_rate_based_kn_candidates.filter.rate_based_kn_candidates',
+    'fink_filters.filter_microlensing_candidates.filter.microlensing_candidates'
 ]
-# does not work because of nested args
-# 'fink_filters.filter_microlensing_candidates.filter.microlensing_candidates',
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #551 / Closes #487 

## What changes were proposed in this pull request?

This PR adds two more filters in production: microlensing candidates and KN candidates from the slope-based filter. Two new substreams are now generated during night operations, with topic names:
- `fink_microlensing_candidates_ztf`
- `fink_rate_based_kn_candidates_ztf`

## How was this patch tested?

CI
