### PR TITLE
Stop the broker at 5pm Paris Time (4pm UTC)

### DIFF
--- a/scheduler/distribution_service.sh
+++ b/scheduler/distribution_service.sh
@@ -20,7 +20,7 @@ while true; do
         echo "Launching service"
 
         # LEASETIME must be computed by taking the difference between now and max end (9pm CEST)
-        LEASETIME=$(( `date +'%s' -d '21:00 today'` - `date +'%s' -d 'now'` ))
+        LEASETIME=$(( `date +'%s' -d '17:00 today'` - `date +'%s' -d 'now'` ))
 
         ${FINK_HOME}/bin/fink start distribution -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_distribute --night ${NIGHT} --exit_after ${LEASETIME} #> ${FINK_HOME}/raw2science_${NIGHT}.log 2>&1 &
         exit

--- a/scheduler/launch_fink.sh
+++ b/scheduler/launch_fink.sh
@@ -16,8 +16,8 @@ source ~/.bash_profile
 #NIGHT=${YEAR}${MONTH}${DAY}
 NIGHT=`date +"%Y%m%d" -d "now + 1 days"`
 
-# 23 hours lease
-LEASETIME=82800
+# 19 hours lease
+LEASETIME=68400
 
 # stream2raw
 nohup fink start stream2raw -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_stream2raw --topic "ztf_${NIGHT}.*" --exit_after ${LEASETIME} > ${FINK_HOME}/broker_logs/stream2raw_${NIGHT}.log 2>&1 &

--- a/scheduler/science_service.sh
+++ b/scheduler/science_service.sh
@@ -22,7 +22,7 @@ while true; do
         #echo "fink start raw2science -c conf_cluster/fink.conf.ztf_raw2science --night ${NIGHT} --exit_after ${LEASETIME}"
 
         # LEASETIME must be computed by taking the difference between now and max end (9pm CE(S)T)
-        LEASETIME=$(( `date +'%s' -d '21:00 today'` - `date +'%s' -d 'now'` ))
+        LEASETIME=$(( `date +'%s' -d '17:00 today'` - `date +'%s' -d 'now'` ))
 
         ${FINK_HOME}/bin/fink start raw2science -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_raw2science --night ${NIGHT} --exit_after ${LEASETIME} #> ${FINK_HOME}/raw2science_${NIGHT}.log 2>&1 &
         exit


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #581 

## What changes were proposed in this pull request?

this PR moves the dates the broker stops at 5pm Paris time, instead of 9pm. To do:

- [ ] change the cronjob for database operations at 5.05pm instead of 9.05pm (Paris time).

## How was this patch tested?

None
