### PR TITLE
[Bug] Fix wrong slicing when correlating with TNS catalog

### DIFF
--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -255,9 +255,9 @@ def main():
             idx, d2d, d3d = catalog_tns.match_to_catalog_sky(catalog_ztf)
 
             sub_pdf = pd.DataFrame({
-                'objectId': objectid.values[idx],
-                'ra': ra.values[idx],
-                'dec': dec.values[idx],
+                'objectId': objectid.values,
+                'ra': ra.values,
+                'dec': dec.values,
             })
 
             # cross-match
@@ -267,7 +267,7 @@ def main():
             sep_constraint2 = d2d2.degree < 1.5 / 3600
 
             sub_pdf['TNS'] = [''] * len(sub_pdf)
-            sub_pdf['TNS'][idx2[sep_constraint2]] = type2.values[idx2[sep_constraint2]]
+            sub_pdf['TNS'][sep_constraint2] = type2.values[idx2[sep_constraint2]]
 
             to_return = objectid.apply(
                 lambda x: '' if x not in sub_pdf['objectId'].values


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #600 

## What changes were proposed in this pull request?

This PR updates the way we cross-correlate ZTF alerts with the TNS catalog. Note, since this buggy code was also used in fink-science to correlate with other catalogs (not yet deployed) -- we might want to check fink_science.xmatch...

## How was this patch tested?

Manually