### PR TITLE
[WIP] check fink-fat installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
     - name: Run test suites [prod]
       if: matrix.container == 'julienpeloton/fink-ci:prod'
       run: |
+        pip install fink-fat
         cd $USRLIBS
         source scripts/start_services.sh --kafka-version ${KAFKA_VERSION} --hbase-version ${HBASE_VERSION}
         cd $FINK_HOME

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,6 @@ jobs:
     - name: Run test suites [prod]
       if: matrix.container == 'julienpeloton/fink-ci:prod'
       run: |
-        pip install fink-fat
         cd $USRLIBS
         source scripts/start_services.sh --kafka-version ${KAFKA_VERSION} --hbase-version ${HBASE_VERSION}
         cd $FINK_HOME


### PR DESCRIPTION
all good, only minor change with  respect  to the current baseline (prod):

```
Installing collected packages: fink-utils, terminaltables, scikit-learn, fink-fat
  Attempting uninstall: fink-utils
    Found existing installation: fink-utils 0.2.2
    Uninstalling fink-utils-0.2.2:
      Successfully uninstalled fink-utils-0.2.2
  Attempting uninstall: scikit-learn
    Found existing installation: scikit-learn 0.23.0
    Uninstalling scikit-learn-0.23.0:
      Successfully uninstalled scikit-learn-0.23.0
```

https://github.com/astrolabsoftware/fink-broker/runs/6825997751?check_suite_focus=true

To do:
- [ ] update the docker files.
- [ ] deploy on the cluster