### PR TITLE
Fix reader syntax for recent versions of fastavro

### DIFF
--- a/bin/fink_test
+++ b/bin/fink_test
@@ -95,9 +95,7 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
 
   # Connect the service to build the science database from the raw one
   fink start raw2science --exit_after 60 -c $conf --night "20190903"
-  ls $FINK_HOME/online
-  ls $FINK_HOME/online/science
-  ls $FINK_HOME/online/science/*
+  ls $FINK_HOME/online/raw/year=2019/month=09/day=03
 
   # Connect to the distribution service
   fink start distribution_test --exit_after 30 -c $conf &

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -94,8 +94,8 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   fink start stream2raw --simulator --exit_after 60 -c $conf --topic $KAFKA_TOPIC
 
   # Connect the service to build the science database from the raw one
-  fink start raw2science --exit_after 60 -c $conf --night "20190903"
-  ls $FINK_HOME/online/raw/year=2019/month=09/day=03
+  fink start raw2science --exit_after 120 -c $conf --night "20190903"
+  ls $FINK_HOME/online/science/year=2019/month=09/day=03
 
   # Connect to the distribution service
   fink start distribution_test --exit_after 30 -c $conf &

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -95,6 +95,9 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
 
   # Connect the service to build the science database from the raw one
   fink start raw2science --exit_after 60 -c $conf --night "20190903"
+  ls $FINK_HOME/online
+  ls $FINK_HOME/online/science
+  ls $FINK_HOME/online/science/*
 
   # Connect to the distribution service
   fink start distribution_test --exit_after 30 -c $conf &

--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -80,7 +80,7 @@ def main():
         )
     elif 'public2.alerts.ztf' in args.servers:
         # Decode on-the-fly using fastavro
-        f = F.udf(lambda x: fastavro.reader(io.BytesIO(x)).next(), alert_schema)
+        f = F.udf(lambda x: next(fastavro.reader(io.BytesIO(x))), alert_schema)
         df_decoded = df.select(
             [
                 f(df['value']).alias("decoded")


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #615 

## What changes were proposed in this pull request?

Change the syntax to get the next message  when using the fastavro reader. Requires recent version of fastavro (1.5.0+)

## How was this patch tested?

Manually
