### PR TITLE
[Elasticc] smoother processing

### DIFF
--- a/bin/distribute_elasticc.py
+++ b/bin/distribute_elasticc.py
@@ -32,7 +32,7 @@ from fink_broker.parser import getargs
 from fink_broker.sparkUtils import init_sparksession, connect_to_raw_database
 from fink_broker.distributionUtils import get_kafka_df
 from fink_broker.loggingUtils import get_fink_logger, inspect_application
-from fink_broker.partitioning import convert_to_datetime
+from fink_broker.partitioning import convert_to_millitime
 
 def format_df_to_elasticc(df):
     """ Take the input DataFrame, and format it for ELAsTICC post-processing
@@ -61,7 +61,7 @@ def format_df_to_elasticc(df):
     # Add non existing columns
     df = df.withColumn(
         'elasticcPublishTimestamp',
-        convert_to_datetime(
+        convert_to_millitime(
             df['diaSource.midPointTai'],
             F.lit('mjd')
         )

--- a/bin/raw2science.py
+++ b/bin/raw2science.py
@@ -57,19 +57,25 @@ def main():
     scitmpdatapath = args.online_data_prefix + '/science'
     checkpointpath_sci_tmp = args.online_data_prefix + '/science_checkpoint'
 
-    df = connect_to_raw_database(
-        rawdatapath + "/year={}/month={}/day={}".format(
-            args.night[0:4],
-            args.night[4:6],
-            args.night[6:8]
-        ),
-        rawdatapath + "/year={}/month={}/day={}".format(
-            args.night[0:4],
-            args.night[4:6],
-            args.night[6:8]
-        ),
-        latestfirst=False
-    )
+    if args.night == 'elasticc':
+        df = connect_to_raw_database(
+            rawdatapath, rawdatapath, latestfirst=False
+        )
+    else:
+        # assume YYYYMMHH
+        df = connect_to_raw_database(
+            rawdatapath + "/year={}/month={}/day={}".format(
+                args.night[0:4],
+                args.night[4:6],
+                args.night[6:8]
+            ),
+            rawdatapath + "/year={}/month={}/day={}".format(
+                args.night[0:4],
+                args.night[4:6],
+                args.night[6:8]
+            ),
+            latestfirst=False
+        )
 
     # Apply science modules
     if 'candidate' in df.columns:

--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -81,14 +81,13 @@ def main():
             ]
         )
     elif 'elasticc' in args.topic:
-        print('READING ELASTICC')
         schema = fastavro.schema.load_schema(args.schema)
         alert_schema_json = fastavro.schema.to_parsing_canonical_form(schema)
         df_decoded = df.select(
             [
                 from_avro(df["value"], alert_schema_json).alias("decoded")
             ]
-    )
+        )
     elif 'public2.alerts.ztf' in args.servers:
         # Decode on-the-fly using fastavro
         f = F.udf(lambda x: next(fastavro.reader(io.BytesIO(x))), alert_schema)

--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -28,6 +28,7 @@ structured-streaming-programming-guide.html#starting-streaming-queries
 from pyspark.sql import functions as F
 
 import fastavro
+import fastavro.schema
 import argparse
 import time
 import io
@@ -67,7 +68,8 @@ def main():
         kerberos=kerberos)
 
     # Get Schema of alerts
-    alert_schema, _, alert_schema_json = get_schemas_from_avro(args.schema)
+    if 'elasticc' not in args.topic:
+        alert_schema, _, alert_schema_json = get_schemas_from_avro(args.schema)
 
     # Decode the Avro data, and keep only (timestamp, data)
     if '134.158.' in args.servers or 'localhost' in args.servers:
@@ -78,6 +80,15 @@ def main():
                 from_avro(df["value"], alert_schema_json).alias("decoded")
             ]
         )
+    elif 'elasticc' in args.topic:
+        print('READING ELASTICC')
+        schema = fastavro.schema.load_schema(args.schema)
+        alert_schema_json = fastavro.schema.to_parsing_canonical_form(schema)
+        df_decoded = df.select(
+            [
+                from_avro(df["value"], alert_schema_json).alias("decoded")
+            ]
+    )
     elif 'public2.alerts.ztf' in args.servers:
         # Decode on-the-fly using fastavro
         f = F.udf(lambda x: next(fastavro.reader(io.BytesIO(x))), alert_schema)

--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -39,7 +39,7 @@ from fink_broker.sparkUtils import from_avro
 from fink_broker.sparkUtils import init_sparksession, connect_to_kafka
 from fink_broker.sparkUtils import get_schemas_from_avro
 from fink_broker.loggingUtils import get_fink_logger, inspect_application
-from fink_broker.partitioning import convert_to_datetime
+from fink_broker.partitioning import convert_to_datetime, convert_to_millitime
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -118,7 +118,11 @@ def main():
         # Add ingestion timestamp
         df_decoded = df_decoded.withColumn(
             'brokerIngestTimestamp',
-            F.current_timestamp()
+            convert_to_millitime(
+                df_decoded['candidate.jd'],
+                F.lit('jd'),
+                F.lit(True)
+            )
         )
 
     df_partitionedby = df_decoded\

--- a/fink_broker/distributionUtils.py
+++ b/fink_broker/distributionUtils.py
@@ -78,7 +78,7 @@ def get_kafka_df(
         # The idea is to force the output schema
         # Need better handling of this though...
         jsonschema = open(
-            '/home/julien.peloton/plasticc_alerts/Examples/plasticc_schema/elasticc.v0_9.brokerClassification.avsc',
+            '/home/julien.peloton/elasticc/alert_schema/elasticc.v0_9.brokerClassification.avsc',
             'r'
         ).read()
         df_kafka = df_struct.select(to_avro_native("struct", jsonschema).alias("value"))

--- a/fink_broker/partitioning.py
+++ b/fink_broker/partitioning.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import TimestampType
+from pyspark.sql.types import TimestampType, LongType
 from pyspark.sql import SparkSession
 
 import numpy as np
@@ -21,6 +21,23 @@ import pandas as pd
 from astropy.time import Time
 
 from fink_broker.tester import spark_unit_tests
+
+@pandas_udf(LongType(), PandasUDFType.SCALAR)
+def convert_to_millitime(jd: pd.Series, format=None):
+    if format is None:
+        formatval = 'jd'
+    else:
+        formatval = format.values[0]
+
+    return pd.Series(
+        np.array(
+            Time(
+                jd.values,
+                format=formatval
+            ).unix * 1000,
+            dtype=int
+        )
+    )
 
 @pandas_udf(TimestampType(), PandasUDFType.SCALAR)
 def convert_to_datetime(jd: pd.Series, format=None) -> pd.Series:

--- a/fink_broker/partitioning.py
+++ b/fink_broker/partitioning.py
@@ -24,6 +24,34 @@ from fink_broker.tester import spark_unit_tests
 
 @pandas_udf(LongType(), PandasUDFType.SCALAR)
 def convert_to_millitime(jd: pd.Series, format=None, now=None):
+    """ Convert date into unix milliseconds (long)
+
+    Parameters
+    ----------
+    jd: double
+        Julian date
+    format: str, optional
+        Astropy time format, e.g. jd, mjd, ... Default is jd.
+    now: boolean, optional
+        If True, return the current time. Default is False
+
+    Returns
+    ----------
+    out: pd.Series
+        Unix milliseconds in UTC
+
+    Examples
+    ----------
+    >>> from fink_broker.sparkUtils import load_parquet_files
+    >>> df = load_parquet_files("online/raw")
+    >>> df = df.withColumn('millis', convert_to_millitime(df['candidate.jd']))
+    >>> pdf = df.select('millis').toPandas()
+
+    >>> import pyspark.sql.functions as F
+    >>> df = df.withColumn('millis', convert_to_millitime(
+    ...     df['candidate.jd'], F.lit('jd'), F.lit(True)))
+    >>> pdf = df.select('millis').toPandas()
+    """
     if format is None:
         formatval = 'jd'
     else:

--- a/fink_broker/partitioning.py
+++ b/fink_broker/partitioning.py
@@ -23,18 +23,23 @@ from astropy.time import Time
 from fink_broker.tester import spark_unit_tests
 
 @pandas_udf(LongType(), PandasUDFType.SCALAR)
-def convert_to_millitime(jd: pd.Series, format=None):
+def convert_to_millitime(jd: pd.Series, format=None, now=None):
     if format is None:
         formatval = 'jd'
     else:
         formatval = format.values[0]
 
+    if now is not None and now.values[0] is True:
+        times = [int(Time.now().unix * 1000)] * len(jd)
+    else:
+        times = Time(
+            jd.values,
+            format=formatval
+        ).unix * 1000
+
     return pd.Series(
         np.array(
-            Time(
-                jd.values,
-                format=formatval
-            ).unix * 1000,
+            times,
             dtype=int
         )
     )

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -173,9 +173,6 @@ def init_sparksession(name: str, shuffle_partitions: int = None) -> SparkSession
     if shuffle_partitions is not None:
         spark.conf.set("spark.sql.shuffle.partitions", shuffle_partitions)
 
-    # Set the time to UTC
-    spark.conf.set("spark.sql.session.timeZone", "UTC")
-
     # Set spark log level to WARN
     spark.sparkContext.setLogLevel("WARN")
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): 
- Closes #616 
- Closes #627 
- Closes #626 

## What changes were proposed in this pull request?

This PR adds a custom decoder in stream2raw for elasticc stream. In addition, we now assume that: 
- The input topic must contain the word `elasticc`
- We must set `--night=elasticc` when processing the data.  
- timestamps are in Unix milliseconds

## How was this patch tested?

CI & cluster