### PR TITLE
Fix timezone, and date format for elasticc

### DIFF
--- a/bin/distribute_elasticc.py
+++ b/bin/distribute_elasticc.py
@@ -84,19 +84,19 @@ def format_df_to_elasticc(df):
             F.array(
                 F.struct(
                     F.lit('rf_snia_vs_nonia_{}'.format(fsvsn)),
-                    F.lit('coucou'),
+                    F.lit('Probability to be an early SNe Ia based on Random Forest classifier'),
                     F.lit(10),
                     F.col("scores").getItem(0)
                 ),
                 F.struct(
                     F.lit('snn_snia_vs_nonia_{}'.format(fsvsn)),
-                    F.lit('coucou'),
+                    F.lit('Probability to be a SN Ia based on SuperNNova classifier'),
                     F.lit(10),
                     F.col("scores").getItem(1)
                 ),
                 F.struct(
                     F.lit('snn_sn_vs_all_{}'.format(fsvsn)),
-                    F.lit('coucou'),
+                    F.lit('Probability to be a SN based on SuperNNova classifier'),
                     F.lit(10),
                     F.col("scores").getItem(2)
                 ),
@@ -112,7 +112,8 @@ def main():
     # Initialise Spark session
     spark = init_sparksession(
         name="distribute_elasticc_{}".format(args.night),
-        shuffle_partitions=2
+        shuffle_partitions=2,
+        tz='UTC'
     )
 
     # The level here should be controlled by an argument.
@@ -135,12 +136,6 @@ def main():
 
     # The topic name is the filter name
     topicname = args.substream_prefix + 'desc_elasticc'
-
-    # Apply user-defined filter -- dummy
-    f1 = df['rf_snia_vs_nonia'] > 0
-    f2 = df['snn_snia_vs_nonia'] > 0
-    f3 = df['snn_sn_vs_all'] > 0
-    df = df.filter(f1 | f2 | f3)
 
     # Wrap alert data
     df = format_df_to_elasticc(df)

--- a/bin/raw2science.py
+++ b/bin/raw2science.py
@@ -43,8 +43,13 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     args = getargs(parser)
 
+    if args.night == 'elasticc':
+        tz = 'UTC'
+    else:
+        tz = None
+
     # Initialise Spark session
-    spark = init_sparksession(name="raw2science_{}".format(args.night), shuffle_partitions=2)
+    spark = init_sparksession(name="raw2science_{}".format(args.night), shuffle_partitions=2, tz=tz)
 
     # Logger to print useful debug statements
     logger = get_fink_logger(spark.sparkContext.appName, args.log_level)

--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -45,8 +45,13 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     args = getargs(parser)
 
+    if 'elasticc' in args.topics:
+        tz = 'UTC'
+    else:
+        tz = None
+
     # Initialise Spark session
-    spark = init_sparksession(name="stream2raw", shuffle_partitions=2)
+    spark = init_sparksession(name="stream2raw", shuffle_partitions=2, tz=tz)
 
     # The level here should be controlled by an argument.
     logger = get_fink_logger(spark.sparkContext.appName, args.log_level)
@@ -120,7 +125,7 @@ def main():
             'brokerIngestTimestamp',
             convert_to_millitime(
                 df_decoded[timecol],
-                F.lit('jd'),
+                F.lit('mjd'),
                 F.lit(True)
             )
         )

--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -45,7 +45,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     args = getargs(parser)
 
-    if 'elasticc' in args.topics:
+    if 'elasticc' in args.topic:
         tz = 'UTC'
     else:
         tz = None

--- a/fink_broker/partitioning.py
+++ b/fink_broker/partitioning.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import TimestampType, LongType
+from pyspark.sql.types import TimestampType
 from pyspark.sql import SparkSession
 
 import numpy as np
@@ -22,7 +22,7 @@ from astropy.time import Time
 
 from fink_broker.tester import spark_unit_tests
 
-@pandas_udf(LongType(), PandasUDFType.SCALAR)
+@pandas_udf(TimestampType(), PandasUDFType.SCALAR)
 def convert_to_millitime(jd: pd.Series, format=None, now=None):
     """ Convert date into unix milliseconds (long)
 
@@ -57,20 +57,15 @@ def convert_to_millitime(jd: pd.Series, format=None, now=None):
     else:
         formatval = format.values[0]
 
-    if now is not None and now.values[0] is True:
-        times = [int(Time.now().unix * 1000)] * len(jd)
+    if now is not None:
+        times = [Time.now().to_datetime()] * len(jd)
     else:
         times = Time(
             jd.values,
             format=formatval
-        ).unix * 1000
+        ).to_datetime()
 
-    return pd.Series(
-        np.array(
-            times,
-            dtype=int
-        )
-    )
+    return pd.Series(times)
 
 @pandas_udf(TimestampType(), PandasUDFType.SCALAR)
 def convert_to_datetime(jd: pd.Series, format=None) -> pd.Series:

--- a/fink_broker/slackUtils.py
+++ b/fink_broker/slackUtils.py
@@ -136,7 +136,7 @@ def get_show_string(
     +------------+----------------------------+
     <BLANKLINE>
     """
-    return(df._jdf.showString(n, truncate, vertical))
+    return df._jdf.showString(n, truncate, vertical)
 
 def send_slack_alerts(df: DataFrame, channels: str):
     """Send alerts to slack channel

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -139,7 +139,7 @@ def write_to_csv(
         .to_csv(fn, index=False)
     batchdf.unpersist()
 
-def init_sparksession(name: str, shuffle_partitions: int = None) -> SparkSession:
+def init_sparksession(name: str, shuffle_partitions: int = None, tz=None) -> SparkSession:
     """ Initialise SparkSession, the level of log for Spark and
     some configuration parameters
 
@@ -151,6 +151,8 @@ def init_sparksession(name: str, shuffle_partitions: int = None) -> SparkSession
         Number of partition to use when shuffling data.
         Typically better to keep the size of shuffles small.
         Default is None.
+    tz: str, optional
+        Timezone. Default is None.
 
     Returns
     ----------
@@ -172,6 +174,9 @@ def init_sparksession(name: str, shuffle_partitions: int = None) -> SparkSession
     # keep the size of shuffles small
     if shuffle_partitions is not None:
         spark.conf.set("spark.sql.shuffle.partitions", shuffle_partitions)
+
+    if tz is not None:
+        spark.conf.set("spark.sql.session.timeZone", tz)
 
     # Set spark log level to WARN
     spark.sparkContext.setLogLevel("WARN")


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #634 

## What changes were proposed in this pull request?

This PR fixes two problems when processing Elasticc data:

- The timezone in Spark is now fixed to UTC.
- The dates are correctly interpreted in milliseconds by Kafka. The Spark is using the `TimestampType` type, and then Kafka automatically handles the conversion to `Long` when receiving the alert.

## How was this patch tested?

Manually + client
