### PR TITLE
Add crossmatch with 4LAC and 3HSP

### DIFF
--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -213,6 +213,30 @@ def apply_science_modules(df: DataFrame, logger: Logger) -> DataFrame:
         )
     )
 
+    logger.info("New processor: 3HSP (1 arcmin)")
+    df = df.withColumn(
+        '3hsp',
+        crossmatch_other_catalog(
+            df['candidate.candid'], 
+            df['candidate.ra'], 
+            df['candidate.dec'], 
+            F.lit('3hsp'),
+            F.lit(60.0)
+        )
+    )
+
+    logger.info("New processor: 4LAC (1 arcmin)")
+    df = df.withColumn(
+        '4lac',
+        crossmatch_other_catalog(
+            df['candidate.candid'],
+            df['candidate.ra'],
+            df['candidate.dec'],
+            F.lit('4lac'),
+            F.lit(60.0)
+        )
+    )
+
     # Apply level one processor: asteroids
     logger.info("New processor: asteroids")
     args_roid = [


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #655 

## What changes were proposed in this pull request?

This PR adds two new added value: counterpart from 4LAC and 3HSP catalogues. Note that the crossmatch radius is 1 arcminute.

## How was this patch tested?

Manually -- see https://github.com/astrolabsoftware/fink-agn
