### PR TITLE
Externalise schemas for the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         git clone https://github.com/astrolabsoftware/fink-alert-simulator.git
         echo "FINK_ALERT_SIMULATOR=${FINK_HOME}/fink-alert-simulator/rootfs/fink" >> $GITHUB_ENV
     - name: Download schemas
+      run: |
         git clone https://github.com/astrolabsoftware/fink-alert-schemas.git
         echo "FINK_SCHEMA=${FINK_HOME}/fink-alert-schemas" >> $GITHUB_ENV
     - name: Set up env [2/2]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
       run: |
         git clone https://github.com/astrolabsoftware/fink-alert-simulator.git
         echo "FINK_ALERT_SIMULATOR=${FINK_HOME}/fink-alert-simulator/rootfs/fink" >> $GITHUB_ENV
+    - name: Download schemas
+        git clone https://github.com/astrolabsoftware/fink-alert-schemas.git
+        echo "FINK_SCHEMA=${FINK_HOME}/fink-alert-schemas" >> $GITHUB_ENV
     - name: Set up env [2/2]
       run: |
         echo "PYTHONPATH=${FINK_HOME}:${FINK_ALERT_SIMULATOR}:${PYTHONPATH}" >> $GITHUB_ENV

--- a/conf/fink.conf.dev
+++ b/conf/fink.conf.dev
@@ -63,7 +63,7 @@ FINK_TRIGGER_UPDATE=2
 
 # Alert schema
 # Full path to schema to decode the alerts
-FINK_ALERT_SCHEMA=${FINK_HOME}/schemas/template_schema_ZTF_3p3.avro
+FINK_ALERT_SCHEMA=${FINK_HOME}/fink-alert-schemas/ztf/template_schema_ZTF_3p3.avro
 
 # Prefix path on disk to save live data.
 # They can be in local FS (/path/ or files:///path/) or

--- a/conf/fink.conf.prod
+++ b/conf/fink.conf.prod
@@ -63,7 +63,7 @@ FINK_TRIGGER_UPDATE=2
 
 # Alert schema
 # Full path to schema to decode the alerts
-FINK_ALERT_SCHEMA=${FINK_HOME}/schemas/template_schema_ZTF_3p3.avro
+FINK_ALERT_SCHEMA=${FINK_HOME}/fink-alert-schemas/ztf/template_schema_ZTF_3p3.avro
 
 # Prefix path on disk to save live data.
 # They can be in local FS (/path/ or files:///path/) or


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #676 

## What changes were proposed in this pull request?

For the CI, we now use the schemas from https://github.com/astrolabsoftware/fink-alert-schemas

## How was this patch tested?

CI