### PR TITLE
Add support for s3 through s3cmd

### DIFF
--- a/bin/distribute.py
+++ b/bin/distribute.py
@@ -91,7 +91,7 @@ def main():
     df_schema = df_schema.selectExpr(cnames)
 
     path_for_avro = 'schema_{}.avro'.format(args.night)
-    schema = save_and_load_schema(df_schema, path_for_avro)
+    schema = save_and_load_schema(df_schema, path_for_avro, fs=args.fs)
 
     # Retrieve time-series information
     to_expand = [

--- a/bin/fink
+++ b/bin/fink
@@ -293,6 +293,7 @@ elif [[ $service == "distribution" ]]; then
   -substream_prefix ${SUBSTREAM_PREFIX} \
   -tinterval ${FINK_TRIGGER_UPDATE} \
   -night ${NIGHT} \
+  -fs ${FS_KIND} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "merge" ]]; then
   spark-submit --master ${SPARK_MASTER} \
@@ -411,7 +412,7 @@ elif [[ $service == "save_schema" ]]; then
   --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
   ${FINK_HOME}/bin/save_distribution_schema.py ${HELP_ON_SERVICE} ${EXIT_AFTER} \
   -agg_data_prefix ${AGG_DATA_PREFIX} \
-  -night ${NIGHT} -log_level ${LOG_LEVEL}
+  -night ${NIGHT} -fs ${FS_KIND} -log_level ${LOG_LEVEL}
 else
   # In case you give an unknown service
   echo "unknown service: $service" >&2

--- a/bin/fink
+++ b/bin/fink
@@ -155,8 +155,10 @@ if [[ "$INITPATH" = true ]] ; then
     finkdir='mkdir'
   elif [[ "$FS_KIND" = "hdfs" ]] ; then
     finkdir='hdfs dfs -mkdir'
+  elif [[ "$FS_KIND" = "s3" ]] ; then
+    finkdir='s3cmd mb'
   else
-    echo "$FS_KIND file system not understood! Currently available: FS_KIND={local, hdfs}"
+    echo "$FS_KIND file system not understood! Currently available: FS_KIND={local, hdfs, s3}"
     exit 1
   fi
   $finkdir $ONLINE_DATA_PREFIX

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -94,7 +94,7 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   fink start stream2raw --simulator --exit_after 60 -c $conf --topic $KAFKA_TOPIC
 
   # Connect the service to build the science database from the raw one
-  fink start raw2science --exit_after 90 -c $conf --night "20190903"
+  fink start raw2science --exit_after 120 -c $conf --night "20190903"
 
   # Start the distribution service
   fink start distribution --exit_after 30 -c $conf --night "20190903"

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -94,7 +94,7 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   fink start stream2raw --simulator --exit_after 60 -c $conf --topic $KAFKA_TOPIC
 
   # Connect the service to build the science database from the raw one
-  fink start raw2science --exit_after 120 -c $conf --night "20190903"
+  fink start raw2science --exit_after 90 -c $conf --night "20190903"
 
   # Start the distribution service
   fink start distribution --exit_after 30 -c $conf --night "20190903"

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -22,3 +22,4 @@ scikit-image
 healpy
 fink-tns>=0.6
 tensorflow_addons
+s3cmd

--- a/fink_broker/distributionUtils.py
+++ b/fink_broker/distributionUtils.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import json
 import glob
 import subprocess


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #686 

## What changes were proposed in this pull request?

Operations requiring s3 access from the host are now supported. We use `s3cmd` (pip installation). Note that the filesystem type needs to be specified in the configuration file, or in the command line, e.g.

```bash
spark-submit [...] -fs s3 [...]
```

In practice, only the service `distribute` needs it explicitly (to extract data schema).

## How was this patch tested?

CI