### PR TITLE
Shift integration tests in k8s

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         cd $FINK_HOME
         fink init -c ${FINK_HOME}/conf/fink.conf.dev
         fink_simulator -c ${FINK_HOME}/conf/fink_alert_simulator.conf
-        fink_test -c conf/fink.conf.dev --without-integration
+        fink_test -c conf/fink.conf.dev --without-units
     - name: Run test suites [prod]
       if: matrix.container == 'julienpeloton/fink-ci:prod'
       run: |
@@ -75,7 +75,7 @@ jobs:
         cd $FINK_HOME
         fink init -c ${FINK_HOME}/conf/fink.conf.prod
         fink_simulator -c ${FINK_HOME}/conf/fink_alert_simulator.conf
-        fink_test -c conf/fink.conf.prod --without-integration
+        fink_test -c conf/fink.conf.prod
         curl -s https://codecov.io/bash | bash
     - uses: act10ns/slack@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         cd $FINK_HOME
         fink init -c ${FINK_HOME}/conf/fink.conf.dev
         fink_simulator -c ${FINK_HOME}/conf/fink_alert_simulator.conf
-        fink_test -c conf/fink.conf.dev --without-units
+        fink_test -c conf/fink.conf.dev --without-integration
     - name: Run test suites [prod]
       if: matrix.container == 'julienpeloton/fink-ci:prod'
       run: |
@@ -75,7 +75,7 @@ jobs:
         cd $FINK_HOME
         fink init -c ${FINK_HOME}/conf/fink.conf.prod
         fink_simulator -c ${FINK_HOME}/conf/fink_alert_simulator.conf
-        fink_test -c conf/fink.conf.prod
+        fink_test -c conf/fink.conf.prod --without-integration
         curl -s https://codecov.io/bash | bash
     - uses: act10ns/slack@v1
       with:

--- a/bin/fink_test
+++ b/bin/fink_test
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2022 AstroLab Software
+# Copyright 2019-2023 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,35 +94,35 @@ if [[ "$NO_INTEGRATION" = false ]] ; then
   fink start stream2raw --simulator --exit_after 60 -c $conf --topic $KAFKA_TOPIC
 
   # Connect the service to build the science database from the raw one
-  fink start raw2science --exit_after 90 -c $conf --night "20190903"
+  fink start raw2science --exit_after 90 -c $conf --night "20200101"
 
   # Start the distribution service
-  fink start distribution --exit_after 30 -c $conf --night "20190903"
+  fink start distribution --exit_after 30 -c $conf --night "20200101"
 
   # merge data
-  fink start merge -c $conf --night "20190903"
+  fink start merge -c $conf --night "20200101"
 
   # Update science portal
-  fink start science_archival -c $conf --night 20190903
-  fink start index_archival -c $conf --night 20190903 --index_table jd_objectId
-  fink start index_archival -c $conf --night 20190903 --index_table pixel128_jd_objectId
-  fink start index_archival -c $conf --night 20190903 --index_table pixel4096_jd_objectId
-  fink start index_archival -c $conf --night 20190903 --index_table pixel131072_jd_objectId
-  fink start index_archival -c $conf --night 20190903 --index_table class_jd_objectId
-  fink start index_archival -c $conf --night 20190903 --index_table upper_objectId_jd
-  fink start index_archival -c $conf --night 20190903 --index_table uppervalid_objectId_jd
-  fink start index_archival -c $conf --night 20190903 --index_table ssnamenr_jd
-  fink start index_archival -c $conf --night 20190903 --index_table tracklet_objectId
+  fink start science_archival -c $conf --night 20200101
+  fink start index_archival -c $conf --night 20200101 --index_table jd_objectId
+  fink start index_archival -c $conf --night 20200101 --index_table pixel128_jd_objectId
+  fink start index_archival -c $conf --night 20200101 --index_table pixel4096_jd_objectId
+  fink start index_archival -c $conf --night 20200101 --index_table pixel131072_jd_objectId
+  fink start index_archival -c $conf --night 20200101 --index_table class_jd_objectId
+  fink start index_archival -c $conf --night 20200101 --index_table upper_objectId_jd
+  fink start index_archival -c $conf --night 20200101 --index_table uppervalid_objectId_jd
+  fink start index_archival -c $conf --night 20200101 --index_table ssnamenr_jd
+  fink start index_archival -c $conf --night 20200101 --index_table tracklet_objectId
   # Need API KEY
-  # fink start index_archival -c $conf --night 20190903 --index_table tns_jd_objectId
+  # fink start index_archival -c $conf --night 20200101 --index_table tns_jd_objectId
 
   # SSO candidates
-  fink start index_sso_cand_archival -c $conf --night 20190903
+  fink start index_sso_cand_archival -c $conf --night 20200101
 
   # Object tables
-  # fink start object_archival -c $conf --night 20190903
+  # fink start object_archival -c $conf --night 20200101
 
-  fink start stats -c $conf --night 20190903
+  fink start stats -c $conf --night 20200101
 
   fink start check_science_portal -c $conf
 else
@@ -130,10 +130,10 @@ else
   fink_simulator --docker -c ${FINK_HOME}/conf/fink_alert_simulator.conf
 
   # Connect the service to build the raw database from the stream
-  fink start stream2raw --exit_after 30 --simulator -c $conf --topic $KAFKA_TOPIC
+  fink start stream2raw --exit_after 60 --simulator -c $conf --topic $KAFKA_TOPIC
 
   # Connect the service to build the science database from the raw one
-  fink start raw2science --exit_after 40 -c $conf --night "20190903"
+  fink start raw2science --exit_after 40 -c $conf --night "20200101"
 fi
 
 if [[ "$NO_UNITS" = false ]] ; then

--- a/fink_broker/hbaseUtils.py
+++ b/fink_broker/hbaseUtils.py
@@ -552,7 +552,7 @@ def select_relevant_columns(df: DataFrame, cols: list, row_key_name: str, to_cre
     # Add the row key to the list of columns to extract
     all_cols = cols + [row_key_name]
 
-    if (to_create is not None) and (type(to_create) == list):
+    if (to_create is not None) and isinstance(to_create, list):
         for extra_col in to_create:
             all_cols += [extra_col]
 
@@ -669,7 +669,7 @@ def construct_hbase_catalog_from_flatten_schema(
         #     sep = ""
 
         # Deal with array
-        if type(column["type"]) == dict:
+        if isinstance(column["type"], dict):
             # column["type"]["type"]
             column["type"] = "string"
 

--- a/itest/finkctl.yaml
+++ b/itest/finkctl.yaml
@@ -16,12 +16,12 @@ stream2raw:
   kafka_starting_offset: earliest
   kafka_topic: ztf-stream-sim
 raw2science:
-  night: "20190903"
+  night: "20200101"
 distribution:
   # Comma-separated list of kafka servers, default to stream2raw.kafka_socket
   # distribution_servers: "kafka_server1:kafka_server2"
   distribution_schema: "/home/fink/fink-alert-schemas/ztf/distribution_schema_0p2.avsc"
   substream_prefix: "fink_"
   # Default to <stream2raw.night>
-  # night: "20190903"
+  # night: "20200101"
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #736 

## What changes were proposed in this pull request?

We were currently running the integration tests twice, in Sentinel & in k8s-based tests. This PR disable (but does not erase) integration tests in Sentinel.

In addition, the date for test alerts has been moved from `20190903` to `20200101` (leftover from #735 )

## How was this patch tested?
CI