### PR TITLE
Add support for self-hosted runner in CI

### DIFF
--- a/.github/workflows/itest-gha.yml
+++ b/.github/workflows/itest-gha.yml
@@ -1,0 +1,164 @@
+# Qserv operator CI workflow
+---
+name: "Integration tests"
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+env:
+  FINKCTL_VERSION: v1.1.0-rc1 
+  NOSCIENCE: true
+  MINIMAL: true
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Declare Version Variables
+        id: vars
+        shell: bash
+        run: |
+          DIR=$(pwd)
+          . ./conf.sh
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
+          echo "IMAGE=${IMAGE}"
+      - name: Build fink-broker image for k8s
+        run: |
+          ./build.sh
+      - name: Export fink-broker image
+        run: |
+          docker images
+          echo "${{ env.IMAGE }}"
+          mkdir -p artifacts
+          docker save "${{ env.IMAGE }}" > artifacts/image.tar
+          echo "${{ env.IMAGE }}" > artifacts/image-tag
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docker-artifact
+          path: artifacts
+  integration-tests:
+    name: Run integration tests
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Declare Version Variables
+        id: vars
+        shell: bash
+        run: |
+          echo "FINK_ALERT_SIMULATOR_DIR=$(. ./conf.sh && echo $FINK_ALERT_SIMULATOR_DIR)" >> $GITHUB_ENV
+      - name: Clone fink-alert-simulator code
+        run: ./itest/clone-fink-alert-simulator.sh
+      - name: Create k8s/kind cluster
+        run: |
+          git clone --depth 1 -b "k8s-1.25.0" --single-branch https://github.com/k8s-school/kind-helper.git
+          ./kind-helper/k8s-create.sh -s
+      - name: Load fink-alert-simulator image inside kind
+        run: |
+          DIR="${{ env.FINK_ALERT_SIMULATOR_DIR }}"
+          .  "${{ env.FINK_ALERT_SIMULATOR_DIR }}"/conf.sh
+          if docker exec -t -- kind-control-plane crictl pull "$IMAGE"; then
+            echo "::notice Succeeded to pull $IMAGE"
+          else
+            echo "::error Failed to pull $IMAGE"
+          fi
+      - name: Download image
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-artifact
+          path: artifacts
+      - name: Load container image inside kind
+        run: |
+          kind load image-archive artifacts/image.tar
+          docker exec -- kind-control-plane crictl image
+      - name: Install fink-alert-simulator pre-requisites (argoCD)
+        run: |
+          "${{ env.FINK_ALERT_SIMULATOR_DIR }}"/prereq-install.sh
+      - name: Install strimzi (kafka-operator)
+        run: ./itest/strimzi-install.sh
+      - name: Setup kafka
+        run: ./itest/strimzi-setup.sh
+      - name: Install fink-broker pre-requisites (Spark)
+        run: ./itest/prereq-install.sh
+      - name: Install MinIO
+        run: ./itest/minio-install.sh
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.19.2'
+      - name: Install finkctl
+        run: go install github.com/astrolabsoftware/finkctl@"${{ env.FINKCTL_VERSION }}"
+      - name: Run fink-alert-simulator
+        run: |
+          "${{ env.FINK_ALERT_SIMULATOR_DIR }}"/argo-submit.sh
+          argo watch @latest
+      # - name: Setup tmate session
+      # uses: mxschmitt/action-tmate@v3
+      - name: Run fink-broker
+        run: |
+          ./itest/fink-start.sh
+      - name: Check results
+        run: |
+          ./itest/check-results.sh
+  image-analysis:
+    name: Analyze image
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Download image
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-artifact
+          path: artifacts
+      - name: Load image in local registry
+        run: |
+          docker load --input artifacts/image.tar
+          echo "IMAGE=$(cat artifacts/artifacts/image-tag)" >> $GITHUB_ENV
+      - name: Scan fink-broker image
+        uses: anchore/scan-action@v3
+        id: scan
+        with:
+          image: "${{ env.IMAGE }}"
+          fail-build: false
+      - name: Display SARIF report
+        run: |
+          cat ${{ steps.scan.outputs.sarif }}
+      - name: upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+  push:
+    name: Push fink-broker image to IN2P3 registry
+    runs-on: ubuntu-22.04
+    needs: integration-tests
+    steps:
+      - name: Download image
+        uses: actions/download-artifact@v3
+        with:
+          name: docker-artifact
+          path: artifacts
+      - name: Load image in local registry
+        run: |
+          docker load --input artifacts/image.tar
+          echo "IMAGE=$(cat artifacts/image-tag)" >> $GITHUB_ENV
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          registry: gitlab-registry.in2p3.fr
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - name: Push image to IN2P3 registry
+        run: |
+          docker push ${{ env.IMAGE }}

--- a/.github/workflows/itest-gha.yml
+++ b/.github/workflows/itest-gha.yml
@@ -1,13 +1,11 @@
-# Qserv operator CI workflow
----
-name: "Integration tests"
+name: "Fink-broker e2e workflow (noscience, GHA)"
 on:
   push:
   pull_request:
     branches:
       - master
 env:
-  FINKCTL_VERSION: v1.1.0-rc1 
+  FINKCTL_VERSION: v1.1.0-rc1
   NOSCIENCE: true
   MINIMAL: true
 

--- a/.github/workflows/itest-noscience.yml
+++ b/.github/workflows/itest-noscience.yml
@@ -1,4 +1,4 @@
-name: "Workflow for Fink integration tests based on 'noscience' image"
+name: "Fink-broker e2e workflow (noscience, self-hosted)"
 on:
   push:
   pull_request:

--- a/.github/workflows/itest-noscience.yml
+++ b/.github/workflows/itest-noscience.yml
@@ -1,0 +1,16 @@
+name: "Workflow for Fink integration tests based on 'noscience' image"
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  call-workflow-passing-data:
+    uses: ./.github/workflows/itest.yml
+    with:
+      minimal: true
+      noscience: true
+    secrets:
+      registry_username: ${{ secrets.REGISTRY_USERNAME }}
+      registry_token: ${{ secrets.REGISTRY_TOKEN }}

--- a/.github/workflows/itest-science.yml
+++ b/.github/workflows/itest-science.yml
@@ -1,0 +1,21 @@
+name: "Workflow for Fink integration tests based on 'science' image"
+on:
+  schedule:
+    # At 05:00 UTC on every day-of-week from Monday through Friday.
+    - cron:  '0 5 * * 1-5'
+  push:
+    # branches:
+    #   - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  call-workflow-passing-data:
+    uses: ./.github/workflows/itest.yml
+    with:
+      minimal: false
+      noscience: false
+    secrets:
+      registry_username: ${{ secrets.REGISTRY_USERNAME }}
+      registry_token: ${{ secrets.REGISTRY_TOKEN }}

--- a/.github/workflows/itest-science.yml
+++ b/.github/workflows/itest-science.yml
@@ -1,4 +1,4 @@
-name: "Workflow for Fink integration tests based on 'science' image"
+name: "Fink-broker e2e workflow (science, self-hosted)"
 on:
   schedule:
     # At 05:00 UTC on every day-of-week from Monday through Friday.

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -1,19 +1,60 @@
-# Qserv operator CI workflow
----
-name: "Integration tests"
-on:
-  push:
-  pull_request:
-    branches:
-      - master
-env:
-  NOSCIENCE: true
-  MINIMAL: true
+name: "Reusable workflow for Fink integration tests"
 
+on:
+  workflow_call:
+    inputs:
+      minimal:
+        required: true
+        type: string
+      noscience:
+        required: true
+        type: string
+    secrets:
+      registry_username:
+        required: true
+      registry_token:
+        required: true
+
+env:
+  MINIMAL: ${{ inputs.minimal }}
+  NOSCIENCE: ${{ inputs.noscience }}
+  # Override the self-hosted runner value
+  POD_NAMESPACE: default
+  CI_REPO: docker-registry.docker-registry:5000
 jobs:
   build:
     name: Build image
-    runs-on: ubuntu-22.04
+    # Use an environment variable to set the worker
+    strategy:
+      matrix:
+        runner: [self-hosted, v2]
+    runs-on: ${{ matrix.runner }}
+    outputs:
+      image: ${{ steps.push.outputs.IMAGE }}
+      promoted_image: ${{ steps.push.outputs.PROMOTED_IMAGE }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Build fink-broker image for k8s
+        run: |
+          ./build.sh
+      - name: Push image to local registry
+        id: push
+        run: |
+          DIR=$(pwd)
+          . ./conf.sh
+          docker push $IMAGE
+          echo "IMAGE=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "PROMOTED_IMAGE=$PROMOTED_IMAGE" >> "$GITHUB_OUTPUT"
+  integration-tests:
+    name: Run integration tests
+    strategy:
+      matrix:
+        runner: [self-hosted, v2]
+    runs-on: ${{ matrix.runner }}
+    needs: build
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -25,42 +66,38 @@ jobs:
         run: |
           DIR=$(pwd)
           . ./conf.sh
+          echo "FINK_ALERT_SIMULATOR_DIR=$FINK_ALERT_SIMULATOR_DIR" >> $GITHUB_ENV
           echo "IMAGE=$IMAGE" >> $GITHUB_ENV
-          echo "IMAGE=${IMAGE}"
-      - name: Build fink-broker image for k8s
-        run: |
-          ./build.sh
-      - name: Export fink-broker image
-        run: |
-          docker images
-          echo "${{ env.IMAGE }}"
-          mkdir -p artifacts
-          docker save "${{ env.IMAGE }}" > artifacts/image.tar
-          echo "${{ env.IMAGE }}" > artifacts/image-tag
-      - uses: actions/upload-artifact@v2
-        with:
-          name: docker-artifact
-          path: artifacts
-  integration-tests:
-    name: Run integration tests
-    runs-on: ubuntu-22.04
-    needs: build
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Declare Version Variables
-        id: vars
-        shell: bash
-        run: |
-          echo "FINK_ALERT_SIMULATOR_DIR=$(. ./conf.sh && echo $FINK_ALERT_SIMULATOR_DIR)" >> $GITHUB_ENV
       - name: Clone fink-alert-simulator code
         run: ./itest/clone-fink-alert-simulator.sh
+      - name: Create kind-helper configuration
+        run: |
+          cat <<EOF > $HOME/.kind-helper
+          kind:
+            # Supported only for clusters with one node
+            # Use host directory to share data between host and kind node
+            # host directory will be mounted on /mnt/extra on each node
+            # extraMountPath: /path/to/host/directory
+
+            # Sets "127.0.0.1" as an extra Subject Alternative Names (SANs) for the API Server signing certificate.
+            # See https://kubernetes.io/docs/reference/config-api/kubeadm-config.v1beta3/#kubeadm-k8s-io-v1beta3-APIServer
+            # Usefull to access API server through a ssh tunnel
+            localcertsans: false
+
+            # Use calico CNI instead of kindnet
+            # useCalico: true
+            # Number of worker nodes
+            workers: 0
+
+            # Supported only for clusters with one node
+            # Certificates must be available on kind host at "/etc/docker/certs.d/{{ .PrivateRegistry }}"
+            privateRegistry: "docker-registry.docker-registry:5000"
+          EOF
       - name: Create k8s/kind cluster
         run: |
-          git clone --depth 1 -b "k8s-1.25.0" --single-branch https://github.com/k8s-school/kind-helper.git
-          ./kind-helper/k8s-create.sh -s
+          VERSION="v1.0.2-rc1"
+          curl -sfL https://raw.githubusercontent.com/k8s-school/kind-helper/$VERSION/install.sh | bash
+          kind-helper create
       - name: Load fink-alert-simulator image inside kind
         run: |
           DIR="${{ env.FINK_ALERT_SIMULATOR_DIR }}"
@@ -70,31 +107,34 @@ jobs:
           else
             echo "::error Failed to pull $IMAGE"
           fi
-      - name: Download image
-        uses: actions/download-artifact@v3
-        with:
-          name: docker-artifact
-          path: artifacts
-      - name: Load container image inside kind
+      - name: Load fink-broker image inside kind
         run: |
-          kind load image-archive artifacts/image.tar
-          docker exec -- kind-control-plane crictl image
-      - name: Install fink-alert-simulator pre-requisites (argoCD)
+          IMAGE=${{ needs.build.outputs.image }}
+          if docker exec -t -- kind-control-plane crictl pull "$IMAGE"; then
+            echo "::notice Succeeded to pull $IMAGE"
+          else
+            echo "::error Failed to pull $IMAGE"
+          fi
+      - name: Install fink-alert-simulator pre-requisites (argo-workflows)
         run: |
+          # sleep infinity
           "${{ env.FINK_ALERT_SIMULATOR_DIR }}"/prereq-install.sh
       - name: Install strimzi (kafka-operator)
         run: ./itest/strimzi-install.sh
       - name: Setup kafka
         run: ./itest/strimzi-setup.sh
       - name: Install fink-broker pre-requisites (Spark)
-        run: ./itest/prereq-install.sh
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install openjdk-8-jdk-headless
+          ./itest/prereq-install.sh
       - name: Install MinIO
         run: ./itest/minio-install.sh
       - uses: actions/setup-go@v4
         with:
           go-version: '1.19.2'
       - name: Install finkctl
-        run: go install github.com/astrolabsoftware/finkctl@v1.0.3
+        run: go install github.com/astrolabsoftware/finkctl@main
       - name: Run fink-alert-simulator
         run: |
           "${{ env.FINK_ALERT_SIMULATOR_DIR }}"/argo-submit.sh
@@ -103,31 +143,26 @@ jobs:
       # uses: mxschmitt/action-tmate@v3
       - name: Run fink-broker
         run: |
-          sleep 10
-          ./itest/itest.sh
+          ./itest/fink-start.sh
   image-analysis:
     name: Analyze image
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        runner: [self-hosted, v2]
+    runs-on: ${{ matrix.runner }}
     permissions:
       security-events: write
     needs: build
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Download image
-        uses: actions/download-artifact@v3
-        with:
-          name: docker-artifact
-          path: artifacts
-      - name: Load image in local registry
+      - name: Pull image from local registry
         run: |
-          docker load --input artifacts/image.tar
-          echo "IMAGE=$(cat artifacts/artifacts/image-tag)" >> $GITHUB_ENV
+          IMAGE=${{ needs.build.outputs.image }}
+          docker pull "$IMAGE"
       - name: Scan fink-broker image
         uses: anchore/scan-action@v3
         id: scan
         with:
-          image: "${{ env.IMAGE }}"
+          image: "${{ needs.build.outputs.image }}"
           fail-build: false
       - name: Display SARIF report
         run: |
@@ -138,24 +173,22 @@ jobs:
           sarif_file: ${{ steps.scan.outputs.sarif }}
   push:
     name: Push fink-broker image to IN2P3 registry
-    runs-on: ubuntu-22.04
-    needs: integration-tests
+    strategy:
+      matrix:
+        runner: [self-hosted, v2]
+    runs-on: ${{ matrix.runner }}
+    needs: [build, integration-tests, image-analysis]
     steps:
-      - name: Download image
-        uses: actions/download-artifact@v3
-        with:
-          name: docker-artifact
-          path: artifacts
-      - name: Load image in local registry
-        run: |
-          docker load --input artifacts/image.tar
-          echo "IMAGE=$(cat artifacts/image-tag)" >> $GITHUB_ENV
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
           registry: gitlab-registry.in2p3.fr
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_TOKEN }}
+          username: ${{ secrets.registry_username }}
+          password: ${{ secrets.registry_token }}
       - name: Push image to IN2P3 registry
         run: |
-          docker push ${{ env.IMAGE }}
+          IMAGE="${{ needs.build.outputs.image }}"
+          PROMOTED_IMAGE="${{ needs.build.outputs.promoted_image }}"
+          docker pull "$IMAGE"
+          docker tag "$IMAGE" "$PROMOTED_IMAGE"
+          docker push "$PROMOTED_IMAGE"

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -1,4 +1,4 @@
-name: "Reusable workflow for Fink integration tests"
+name: "Reusable workflow for Fink self-hosted e2e tests"
 
 on:
   workflow_call:

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -27,7 +27,7 @@ jobs:
     # Use an environment variable to set the worker
     strategy:
       matrix:
-        runner: [self-hosted, v2]
+        runner: [self-hosted]
     runs-on: ${{ matrix.runner }}
     outputs:
       image: ${{ steps.push.outputs.IMAGE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/*
 
 ADD deps/jars-urls.txt $FINK_HOME/
-RUN xargs -n 1 curl --output-dir /opt/spark/jars -O < $FINK_HOME/jars-urls.txt
+RUN xargs -n 1 curl --fail --output-dir /opt/spark/jars -O < $FINK_HOME/jars-urls.txt
 
 # Main process will run as spark_uid
 ENV HOME /home/fink

--- a/TODO.org
+++ b/TODO.org
@@ -1,3 +1,20 @@
+* 729
+** DONE use "kubectl get kafkatopics.kafka.strimzi.io  -n kafka" to check success of integration tests, maybe in fnkctl?
+** TODO DELAYED BECAUSE IT NOT BLOCKS BUT WARN create topic in distribute before sending alerts in order to avoid error below: https://fink-broker.slack.com/archives/D03KJ390F17/p1692008729660549
+Du coup ça fonctionne avec un compte utilisateur, par contre j'ai pas activé les autorisations dans kafka car le fink-alert-simulator aurait pu plus écrire dans le topic sans authentification.
+12 h 28
+J'ai maintenant ce message d'erreur:
+23/08/14 10:26:52 WARN NetworkClient: [Producer clientId=producer-1] Error while fetching metadata with correlation id 29 : {fink_simbad_grav_candidates_ztf=LEADER_NOT_AVAILABLE}
+12 h 32
+En fait c'est du au fait que le topic existe pas, ça fonctionne si on relance lae job distribute...
+12 h 33
+Tu crois qu'on pourrais pré-créer les topic pour éviter ce problème
+@JulienPeloton
+?
+** DONE add user authentication in kafka https://stackoverflow.com/questions/65729535/how-to-do-i-connect-kafka-python-to-accept-username-and-password-for-jaas-like-i
+* TODO Enable authZ in kafka (require authN setup in fink-alert-simulator)
+* TODO [#B] distribute should wait for data to appear instead of crashing in connect_to_raw_database()
+* TODO move nodeport to internal for svc kafka-cluster-kafka-external-bootstrap
 * TODO improve final test in CI (check Kafka with fink-client https://github.com/astrolabsoftware/fink-client)
 * TODO run code-check.sh in CI
 * DONE add unit test for schema_converter
@@ -5,7 +22,7 @@
 Document +add SO post?:
 Download hadoop binary release: https://www.apache.org/dyn/closer.cgi/hadoop/common/hadoop-3.2.4/hadoop-3.2.4.tar.gz
 extract and copy jar:
- fjammes@clrinfopo18  ~/Downloads/hadoop-3.2.4  cp ./share/hadoop/tools/lib/hadoop-aws-3.2.4.jar ~/src/k8s-spark-py/custom/jars 
+ fjammes@clrinfopo18  ~/Downloads/hadoop-3.2.4  cp ./share/hadoop/tools/lib/hadoop-aws-3.2.4.jar ~/src/k8s-spark-py/custom/jars
  fjammes@clrinfopo18  ~/Downloads/hadoop-3.2.4  cp ./share/hadoop/tools/lib/aws-java-sdk-bundle-1.11.901.jar ~/src/k8s-spark-py/custom/jars
 	// WARNING package are not deployed in spark-executor
 	// see https://stackoverflow.com/a/67299668/2784039
@@ -14,7 +31,7 @@ kubectl logs stream2raw-py-f529af864f8dee60-driver | grep downlo | cut -d' ' -f2
 OR add mnv copy:dependencies when building the image?
 * TODO manage dependencies
 What to do with:
-1. hbase-spark-hbase2.4_spark3_scala2.12_hadoop3.2.jar 
+1. hbase-spark-hbase2.4_spark3_scala2.12_hadoop3.2.jar
 hbase-spark-protocol-shaded-hbase2.4_spark3_scala2.12_hadoop3.2.jar
 which are both in k8s-spark-py/custom and fink-broker/libs (cf. FINK_JARS)
 cf. Julien are they required?

--- a/bin/distribute.py
+++ b/bin/distribute.py
@@ -85,8 +85,10 @@ def main():
     cnames[cnames.index('cutoutDifference')] = 'struct(cutoutDifference.*) as cutoutDifference'
     cnames[cnames.index('prv_candidates')] = 'explode(array(prv_candidates)) as prv_candidates'
     cnames[cnames.index('candidate')] = 'struct(candidate.*) as candidate'
-    cnames[cnames.index('lc_features_g')] = 'struct(lc_features_g.*) as lc_features_g'
-    cnames[cnames.index('lc_features_r')] = 'struct(lc_features_r.*) as lc_features_r'
+    if not args.noscience:
+        # This column is added by the science pipeline
+        cnames[cnames.index('lc_features_g')] = 'struct(lc_features_g.*) as lc_features_g'
+        cnames[cnames.index('lc_features_r')] = 'struct(lc_features_r.*) as lc_features_r'
 
     # Extract schema
     df_schema = spark.read.format('parquet').load(input_sci)
@@ -115,7 +117,10 @@ def main():
         topicname = args.substream_prefix + userfilter.split('.')[-1] + '_ztf'
 
         # Apply user-defined filter
-        df_tmp = apply_user_defined_filter(df, userfilter, logger)
+        if args.noscience:
+            df_tmp = df
+        else:
+            df_tmp = apply_user_defined_filter(df, userfilter, logger)
 
         # Wrap alert data
         df_tmp = df_tmp.selectExpr(cnames)

--- a/conf.sh
+++ b/conf.sh
@@ -13,6 +13,7 @@ MINIMAL="${MINIMAL:-false}"
 # ----------------
 # Repository address
 REPO="gitlab-registry.in2p3.fr/astrolabsoftware/fink"
+CI_REPO="${CI_REPO:-$REPO}"
 # Tag to apply to the built image, or to identify the image to be pushed
 TAG=${FINK_BROKER_RELEASE:-$(git -C $DIR describe --dirty --always)}
 # WARNING "spark-py" is hard-coded in spark build script
@@ -20,9 +21,11 @@ TAG=${FINK_BROKER_RELEASE:-$(git -C $DIR describe --dirty --always)}
 # Disable science pipeline
 if [ "$NOSCIENCE" = true ];
 then
-  IMAGE="$REPO/fink-broker-noscience:$TAG"
+  IMAGE="$CI_REPO/fink-broker-noscience:$TAG"
+  PROMOTED_IMAGE="$REPO/fink-broker-noscience:$TAG"
 else
-  IMAGE="$REPO/fink-broker:$TAG"
+  IMAGE="$CI_REPO/fink-broker:$TAG"
+  PROMOTED_IMAGE="$REPO/fink-broker:$TAG"
 fi
 
 # Spark parameters

--- a/deps/requirements-science.txt
+++ b/deps/requirements-science.txt
@@ -1,5 +1,5 @@
 # Active learning
--e git+https://github.com/emilleishida/fink_sn_activelearning.git@e16152091ff8f9ece8d4823e8da1f498d60ac45f#egg=actsnfink
+-e git+https://github.com/emilleishida/fink_sn_activelearning.git@6c1d04c9581afa7343439beb726edf61d7a18608#egg=actsnfink
 -e git+https://github.com/COINtoolbox/ActSNClass.git@2c61da91a9d13834d39804fc35aeb3245ba20755#egg=actsnclass
 
 # microlensing

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -13,7 +13,7 @@ slackclient
 astropy
 astroquery
 fink_filters>=3.5
-git+https://github.com/astrolabsoftware/fink-science@4.3.0
+git+https://github.com/astrolabsoftware/fink-science@4.4.0
 fink-utils>=0.13.6
 scipy
 scikit-learn==1.0.2

--- a/doc/devel.adoc
+++ b/doc/devel.adoc
@@ -14,7 +14,16 @@ git clone https://github.com/astrolabsoftware/fink-broker.git
 cd fink-broker
 ----
 
-`conf.sh` contains all build parameters with inline documenation for all of them. For example, edit `SPARK_IMAGE_TAG` value in `conf.sh` in order to customize the base image used to `fink-broker` container image.
+=== Configure the build
+
+`conf.sh` contains all build parameters with inline documentation for all of them. For example, edit `SPARK_IMAGE_TAG` value in `conf.sh` in order to customize the base image used to `fink-broker` container image.
+
+[,shell]
+----
+# Work with minimal cpu/memory requirements and no science code
+export MINIMAL=true
+export NOSCIENCE=true
+----
 
 === Build the image:
 
@@ -22,7 +31,6 @@ cd fink-broker
 ----
 ./build.sh
 ----
-
 
 === Push the image to CC-IN2P3 registry
 

--- a/examples/alias-fink.sh
+++ b/examples/alias-fink.sh
@@ -1,0 +1,26 @@
+# Aliases for Fink
+
+# Source it from your .bashrc or .bash_aliases with:
+# if [ -f $HOME/src/fink-broker/examples/alias-fink.sh ]; then
+#     . $HOME/src/fink-broker/examples/alias-fink.sh
+# fi
+
+MYSHELL=$(echo $SHELL)
+MYSHELL=$(basename $MYSHELL)
+source <(finkctl completion $MYSHELL)
+
+FINK_BROKER_SRC_DIR="$HOME/src/fink-broker"
+FINK_ALERT_SIM_SRC_DIR="$HOME/src/fink-alert-simulator"
+FINKCTL_SRC_DIR="$HOME/src/finkctl"
+
+export FINKCONFIG=$FINK_BROKER_SRC_DIR/itest
+
+alias cdfa="cd $FINK_ALERT_SIM_SRC_DIR"
+alias cdfb="cd $FINK_BROKER_SRC_DIR"
+alias cdfc="cd $FINKCTL_SRC_DIR"
+
+alias fns="export MINIMAL=true NOSCIENCE=true"
+alias fbp="$FINK_BROKER_SRC_DIR/build.sh && $FINK_BROKER_SRC_DIR/push-image.sh"
+
+alias fadel="kubectl delete pod -l workflows.argoproj.io/completed"
+alias fabp="$FINK_ALERT_SIM_SRC_DIR/build.sh && $FINK_ALERT_SIM_SRC_DIR/push-image.sh"

--- a/examples/get_fink_secret.sh
+++ b/examples/get_fink_secret.sh
@@ -1,0 +1,1 @@
+kubectl get -n kafka secrets/fink-producer --template={{.data.password}} | base64 --decode

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -108,7 +108,7 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         [TIME_INTERVAL]
         """)
     parser.add_argument(
-        '-exit_after', type=int, default=86400,
+        '-exit_after', type=int, default=64800,
         help="""
         Stop the service after `exit_after` seconds.
         This primarily for use on CI, to stop service after some time.

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -108,11 +108,11 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         [TIME_INTERVAL]
         """)
     parser.add_argument(
-        '-exit_after', type=int, default=None,
+        '-exit_after', type=int, default=86400,
         help="""
         Stop the service after `exit_after` seconds.
-        This primarily for use on Travis, to stop service after some time.
-        Use that with `fink start service --exit_after <time>`. Default is None.
+        This primarily for use on CI, to stop service after some time.
+        Use that with `fink start service --exit_after <time>`. Default is 24h.
         """)
     parser.add_argument(
         '-datasimpath', type=str, default='',
@@ -237,7 +237,7 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         [PRODUCER]
         """)
     parser.add_argument(
-        '-noscience', type=bool, default=False,
+        '--noscience', action="store_true",
         help="""
         Disable execution of science modules
         """)

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -27,13 +27,39 @@ from itertools import chain
 
 from fink_utils.spark.utils import concat_col
 
-
 from fink_broker.tester import spark_unit_tests
+
 
 # ---------------------------------
 # Local non-exported definitions --
 # ---------------------------------
 _LOG = logging.getLogger(__name__)
+
+
+# Conditional import of science modules
+try:
+    from fink_science.random_forest_snia.processor import rfscore_sigmoid_full
+    from fink_science.xmatch.processor import xmatch_cds
+    from fink_science.xmatch.processor import crossmatch_other_catalog
+    from fink_science.xmatch.processor import crossmatch_mangrove
+
+    from fink_science.snn.processor import snn_ia
+    from fink_science.microlensing.processor import mulens
+    from fink_science.asteroids.processor import roid_catcher
+    from fink_science.nalerthist.processor import nalerthist
+    from fink_science.kilonova.processor import knscore
+    from fink_science.ad_features.processor import extract_features_ad
+    from fink_science.anomaly_detection.processor import anomaly_score
+
+    from fink_science.random_forest_snia.processor import rfscore_sigmoid_elasticc
+    from fink_science.snn.processor import snn_ia_elasticc, snn_broad_elasticc
+    from fink_science.cats.processor import predict_nn
+    from fink_science.agn.processor import agn_elasticc
+    from fink_science.slsn.processor import slsn_elasticc
+    # from fink_science.t2.processor import t2
+except ImportError:
+    _LOG.warning("Fink science modules are not available. ")
+    pass
 
 def dec2theta(dec: float) -> float:
     """ Convert Dec (deg) to theta (rad)
@@ -178,26 +204,6 @@ def apply_science_modules(df: DataFrame, noscience: bool = False) -> DataFrame:
     """
     if noscience:
         return df
-
-    from fink_science.random_forest_snia.processor import rfscore_sigmoid_full
-    from fink_science.xmatch.processor import xmatch_cds
-    from fink_science.xmatch.processor import crossmatch_other_catalog
-    from fink_science.xmatch.processor import crossmatch_mangrove
-
-    from fink_science.snn.processor import snn_ia
-    from fink_science.microlensing.processor import mulens
-    from fink_science.asteroids.processor import roid_catcher
-    from fink_science.nalerthist.processor import nalerthist
-    from fink_science.kilonova.processor import knscore
-    from fink_science.ad_features.processor import extract_features_ad
-    from fink_science.anomaly_detection.processor import anomaly_score
-
-    from fink_science.random_forest_snia.processor import rfscore_sigmoid_elasticc
-    from fink_science.snn.processor import snn_ia_elasticc, snn_broad_elasticc
-    from fink_science.cats.processor import predict_nn
-    from fink_science.agn.processor import agn_elasticc
-    from fink_science.slsn.processor import slsn_elasticc
-    # from fink_science.t2.processor import t2
 
     # Retrieve time-series information
     to_expand = [

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -27,25 +27,6 @@ from itertools import chain
 
 from fink_utils.spark.utils import concat_col
 
-from fink_science.random_forest_snia.processor import rfscore_sigmoid_full
-from fink_science.xmatch.processor import xmatch_cds
-from fink_science.xmatch.processor import crossmatch_other_catalog
-from fink_science.xmatch.processor import crossmatch_mangrove
-
-from fink_science.snn.processor import snn_ia
-from fink_science.microlensing.processor import mulens
-from fink_science.asteroids.processor import roid_catcher
-from fink_science.nalerthist.processor import nalerthist
-from fink_science.kilonova.processor import knscore
-from fink_science.ad_features.processor import extract_features_ad
-from fink_science.anomaly_detection.processor import anomaly_score
-
-from fink_science.random_forest_snia.processor import rfscore_sigmoid_elasticc
-from fink_science.snn.processor import snn_ia_elasticc, snn_broad_elasticc
-from fink_science.cats.processor import predict_nn
-from fink_science.agn.processor import agn_elasticc
-from fink_science.slsn.processor import slsn_elasticc
-# from fink_science.t2.processor import t2
 
 from fink_broker.tester import spark_unit_tests
 
@@ -197,6 +178,26 @@ def apply_science_modules(df: DataFrame, noscience: bool = False) -> DataFrame:
     """
     if noscience:
         return df
+
+    from fink_science.random_forest_snia.processor import rfscore_sigmoid_full
+    from fink_science.xmatch.processor import xmatch_cds
+    from fink_science.xmatch.processor import crossmatch_other_catalog
+    from fink_science.xmatch.processor import crossmatch_mangrove
+
+    from fink_science.snn.processor import snn_ia
+    from fink_science.microlensing.processor import mulens
+    from fink_science.asteroids.processor import roid_catcher
+    from fink_science.nalerthist.processor import nalerthist
+    from fink_science.kilonova.processor import knscore
+    from fink_science.ad_features.processor import extract_features_ad
+    from fink_science.anomaly_detection.processor import anomaly_score
+
+    from fink_science.random_forest_snia.processor import rfscore_sigmoid_elasticc
+    from fink_science.snn.processor import snn_ia_elasticc, snn_broad_elasticc
+    from fink_science.cats.processor import predict_nn
+    from fink_science.agn.processor import agn_elasticc
+    from fink_science.slsn.processor import slsn_elasticc
+    # from fink_science.t2.processor import t2
 
     # Retrieve time-series information
     to_expand = [

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -20,8 +20,6 @@ from pyspark.sql import DataFrame
 from pyspark.sql.column import Column, _to_java_column
 from pyspark.sql.types import StructType
 
-from py4j.protocol import Py4JJavaError
-
 import os
 import json
 
@@ -244,9 +242,7 @@ def connect_to_kafka(
     True
     """
     # Grab the running Spark Session
-    spark = SparkSession \
-        .builder \
-        .getOrCreate()
+    spark = SparkSession.builder.getOrCreate()
 
     conf = spark.sparkContext.getConf().getAll()
 
@@ -307,9 +303,7 @@ def connect_to_raw_database(basepath: str, path: str, latestfirst: bool) -> Data
     True
     """
     # Grab the running Spark Session
-    spark = SparkSession \
-        .builder \
-        .getOrCreate()
+    spark = SparkSession.builder.getOrCreate()
 
     wait_sec = 5
     while not path_exist(basepath):
@@ -365,9 +359,7 @@ def path_exist(path: str) -> bool:
     bool
         True if the path exists, False otherwise
     """
-    spark = SparkSession \
-            .builder \
-            .getOrCreate()
+    spark = SparkSession.builder.getOrCreate()
 
     jvm = spark._jvm
     jsc = spark._jsc
@@ -377,8 +369,9 @@ def path_exist(path: str) -> bool:
 
     fs = jvm.org.apache.hadoop.fs.FileSystem.get(uri, conf)
     if fs.exists(jvm.org.apache.hadoop.fs.Path(path)):
-            return True
-    return False
+        return True
+    else:
+        return False
 
 def load_parquet_files(path: str) -> DataFrame:
     """ Initialise SparkSession, and load parquet files with Spark

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -365,16 +365,20 @@ def path_exist(path: str) -> bool:
     bool
         True if the path exists, False otherwise
     """
-    spark = SparkSession.builder.getOrCreate()
+    spark = SparkSession \
+            .builder \
+            .getOrCreate()
 
     jvm = spark._jvm
     jsc = spark._jsc
 
-    fs = jvm.org.apache.hadoop.fs.FileSystem.get(jsc.hadoopConfiguration())
+    conf = jsc.hadoopConfiguration()
+    uri = jvm.java.net.URI(path)
+
+    fs = jvm.org.apache.hadoop.fs.FileSystem.get(uri, conf)
     if fs.exists(jvm.org.apache.hadoop.fs.Path(path)):
-        return True
-    else:
-        return False
+            return True
+    return False
 
 def load_parquet_files(path: str) -> DataFrame:
     """ Initialise SparkSession, and load parquet files with Spark

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -12,12 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import time
 from typing import Tuple
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
 from pyspark.sql import DataFrame
 from pyspark.sql.column import Column, _to_java_column
 from pyspark.sql.types import StructType
+
+from py4j.protocol import Py4JJavaError
 
 import os
 import json
@@ -309,6 +312,10 @@ def connect_to_raw_database(
         .builder \
         .getOrCreate()
 
+    while not path_exist(basepath):
+        print("Waiting for data to arrive in {}".format(basepath))
+        time.sleep(5)
+
     # Create a DF from the database
     userschema = spark\
         .read\
@@ -325,6 +332,27 @@ def connect_to_raw_database(
         .load()
 
     return df
+
+def path_exist(path: str) -> bool:
+    """Check if a path exists on Spark FS
+
+    Parameters
+    ----------
+    path : str
+        Path to check
+
+    Returns
+    -------
+    bool
+        True if the path exists, False otherwise
+    """
+    sc = SparkContext._active_spark_context
+    try:
+        rdd = sc.textFile(path)
+        rdd.take(1)
+        return True
+    except Py4JJavaError as e:
+        return False
 
 def load_parquet_files(path: str) -> DataFrame:
     """ Initialise SparkSession, and load parquet files with Spark

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -351,7 +351,7 @@ def path_exist(path: str) -> bool:
         rdd = sc.textFile(path)
         rdd.take(1)
         return True
-    except Py4JJavaError as e:
+    except Py4JJavaError:
         return False
 
 def load_parquet_files(path: str) -> DataFrame:

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -312,9 +312,12 @@ def connect_to_raw_database(
         .builder \
         .getOrCreate()
 
+    wait_sec = 5
     while not path_exist(basepath):
         print("Waiting for data to arrive in {}".format(basepath))
-        time.sleep(5)
+        time.sleep(wait_sec)
+        # Sleep for longer and longer
+        wait_sec = increase_wait_time(wait_sec)
 
     # Create a DF from the database
     userschema = spark\
@@ -333,8 +336,25 @@ def connect_to_raw_database(
 
     return df
 
+def increase_wait_time(wait_sec: int) -> int:
+    """ Increase the waiting time between two checks by 20%
+
+    Parameters
+    ----------
+    wait_sec : int
+        Current waiting time in seconds
+
+    Returns
+    -------
+    int
+        New waiting time in seconds, maximum 60 seconds
+    """
+    if wait_sec < 60:
+        wait_sec *= 1.2
+    return wait_sec
+
 def path_exist(path: str) -> bool:
-    """Check if a path exists on Spark FS
+    """Check if a path exists on Spark shared filesystem (HDFS or S3)
 
     Parameters
     ----------

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -281,8 +281,7 @@ def connect_to_kafka(
 
     return df
 
-def connect_to_raw_database(
-        basepath: str, path: str, latestfirst: bool) -> DataFrame:
+def connect_to_raw_database(basepath: str, path: str, latestfirst: bool) -> DataFrame:
     """ Initialise SparkSession, and connect to the raw database (Parquet)
 
     Parameters
@@ -366,12 +365,15 @@ def path_exist(path: str) -> bool:
     bool
         True if the path exists, False otherwise
     """
-    sc = SparkContext._active_spark_context
-    try:
-        rdd = sc.textFile(path)
-        rdd.take(1)
+    spark = SparkSession.builder.getOrCreate()
+
+    jvm = spark._jvm
+    jsc = spark._jsc
+
+    fs = jvm.org.apache.hadoop.fs.FileSystem.get(jsc.hadoopConfiguration())
+    if fs.exists(jvm.org.apache.hadoop.fs.Path(path)):
         return True
-    except Py4JJavaError:
+    else:
         return False
 
 def load_parquet_files(path: str) -> DataFrame:

--- a/itest/check-results.sh
+++ b/itest/check-results.sh
@@ -16,38 +16,15 @@
 # limitations under the License.
 #
 
-# Setup Kafka for Fink
+# Create docker image containing Fink packaged for k8s
 
 # @author  Fabrice Jammes
 
-set -euxo pipefail
+set -euo pipefail
 
 DIR=$(cd "$(dirname "$0")"; pwd -P)
 
-readonly  FINKKUB=$(readlink -f "${DIR}/..")
-. $FINKKUB/conf.sh
+. $DIR/../conf.sh
 
-cat << EOF | kubectl create -n $KAFKA_NS -f -
-apiVersion: kafka.strimzi.io/v1beta2
-kind: KafkaUser
-metadata:
-  name: fink-producer
-  labels:
-    strimzi.io/cluster: "$KAFKA_CLUSTER"
-spec:
-  authentication:
-    type: scram-sha-512
-EOF
-
-cat << EOF | kubectl create -n $KAFKA_NS -f -
-apiVersion: kafka.strimzi.io/v1beta2
-kind: KafkaTopic
-metadata:
-  name: ztf-stream-sim
-  labels:
-    strimzi.io/cluster: "$KAFKA_CLUSTER"
-spec:
-  partitions: 3
-  replicas: 1
-EOF
-
+finkctl wait topics --expected 10 --timeout 240s
+finkctl get topics

--- a/itest/finkctl.secret.yaml
+++ b/itest/finkctl.secret.yaml
@@ -1,3 +1,10 @@
 s3:
   id: "minioadmin"
   secret: "minioadmin"
+distribution:
+  kafka:
+    username: "fink-producer"
+    # If empty, password is set to "kubectl get -n kafka secrets/fink-producer --template={{.data.password}} | base64 --decode"
+    # this is used for integration tests and CI which use a local kafka cluster
+    password: ""
+

--- a/itest/finkctl.yaml
+++ b/itest/finkctl.yaml
@@ -2,7 +2,8 @@ s3:
   endpoint: http://minio.minio-dev:9000
   use_ssl: "false"
   bucket: fink-broker-online
-spark:
+# General parameter used to run fink tasks
+run:
   fink_trigger_update: "2"
   # Can be set using --image option
   # image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-broker:2.7.1-33-ge27a2aa-dirty
@@ -12,14 +13,14 @@ spark:
   log_level: INFO
 stream2raw:
   fink_alert_schema: /home/fink/fink-alert-schemas/ztf/ztf_public_20190903.schema.avro
-  kafka_socket: kafka-cluster-kafka-external-bootstrap.kafka:9094
+  kafka_socket: kafka-cluster-kafka-bootstrap.kafka:9092
   kafka_starting_offset: earliest
   kafka_topic: ztf-stream-sim
 raw2science:
   night: "20200101"
 distribution:
   # Comma-separated list of kafka servers, default to stream2raw.kafka_socket
-  # distribution_servers: "kafka_server1:kafka_server2"
+  distribution_servers: "kafka-cluster-kafka-external-bootstrap.kafka:9094"
   distribution_schema: "/home/fink/fink-alert-schemas/ztf/distribution_schema_0p2.avsc"
   substream_prefix: "fink_"
   # Default to <stream2raw.night>

--- a/itest/manifests/minio.yaml
+++ b/itest/manifests/minio.yaml
@@ -16,6 +16,18 @@ spec:
     - protocol: TCP
       port: 9000
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-dev
+  namespace: minio-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,9 +55,8 @@ spec:
         - minio server /data --console-address :9090
         volumeMounts:
         - mountPath: /data
-          name: localvolume
+          name: data
       volumes:
-      - name: localvolume
-        hostPath: # MinIO generally recommends using locally-attached volumes
-          path: /data/minio
-          type: DirectoryOrCreate
+      - name: data
+        persistentVolumeClaim:
+          claimName: minio-dev

--- a/itest/prereq-install.sh
+++ b/itest/prereq-install.sh
@@ -24,8 +24,7 @@ set -euxo pipefail
 
 DIR=$(cd "$(dirname "$0")"; pwd -P)
 
-readonly  FINKKUB=$(readlink -f "${DIR}/..")
-. $FINKKUB/conf.sh
+. $DIR/../conf.sh
 
 mkdir -p "$SPARK_INSTALL_DIR"
 

--- a/itest/strimzi-install.sh
+++ b/itest/strimzi-install.sh
@@ -80,12 +80,14 @@ spec:
         port: 9094
         type: nodeport
         tls: false
+        authentication:
+          type: scram-sha-512
     storage:
       type: jbod
       volumes:
       - id: 0
         type: persistent-claim
-        size: 100Gi
+        size: 1Gi
         deleteClaim: false
     config:
       offsets.topic.replication.factor: 1
@@ -97,7 +99,7 @@ spec:
     replicas: 1
     storage:
       type: persistent-claim
-      size: 100Gi
+      size: 1Gi
       deleteClaim: false
   entityOperator:
     topicOperator: {}


### PR DESCRIPTION

Linked to issue(s): Closes #729 

## What changes were proposed in this pull request?

Important features implemented:
- Wait for data on spark storage instead of crashing in raw2science and distribute drivers
- Wait for topics to appear in order to validate integration tests have passed in CI
- Add support for kafka AuthN

And also:
- Override POD_NAMESPACE on CI node
- Run CI with the science image
- Add support for reusable workflow
- Add support for secrets
- Use self-hosted runner internal registry
- Add integration test with science algorithms
- Test insecure registry setup in kind
- Add conditional import of science modules
- Fail CI if the number of spark pods is not correct
- Remove column 'lc_features_g' from noscience pipeline
- Disable apply_user_defined_filter() in noscience pipeline
- Install jdk in CI
- Increase fink startup control delay
- Add default value for fink-broker '--exit-after' option
- Fail docker build if not able to curl a jar file
- Set kafka volumes size to 1Gi
- Use pvc for minio
- Add user aliases
- Disable AuthZ in kafka
- Enable GHA ci for noscience pipeline


## How was this patch tested?

The "noscience" pipeline works fine on GHA, but there is still an issue with the docker registry on self-hosted runner. However "noscience" and "science" integration tests have passed successfully on the self-hosted runner.
