### PR TITLE
Add more columns for uppervalid alerts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-suite:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,12 @@ jobs:
     - name: Run test suites [dev]
       if: matrix.container == 'julienpeloton/fink-ci:dev'
       run: |
+        # TODO: remove me
+        pip install fink-utils==0.13.11
         cd $USRLIBS
         source scripts/start_services.sh --kafka-version ${KAFKA_VERSION} --hbase-version ${HBASE_VERSION}
         cd $FINK_HOME
-        fink_test -c conf/fink.conf.dev --unit-tests
+        fink_test -c conf/fink.conf.dev --unit-tests --db-integration
     - name: Run test suites [prod]
       if: matrix.container == 'julienpeloton/fink-ci:prod'
       run: |

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -265,7 +265,7 @@ def main():
             "tmp",
             F.arrays_zip(
                 "magpsf", "sigmapsf", "diffmaglim", "jd", "fid",
-                "magnr", "sigmagnr", "isdiffpos", "distnr"
+                "magnr", "sigmagnr", "isdiffpos", "distnr",
                 "rb", "nbad"
             )
         ).withColumn("tmp", F.explode("tmp")).select(

--- a/bin/index_archival.py
+++ b/bin/index_archival.py
@@ -253,6 +253,7 @@ def main():
             F.col('prv_candidates.magnr').cast('array<float>').alias('magnr'),
             F.col('prv_candidates.sigmagnr').cast('array<float>').alias('sigmagnr'),
             F.col('prv_candidates.isdiffpos').cast('array<string>').alias('isdiffpos'),
+            F.col('prv_candidates.distnr').cast('array<float>').alias('distnr'),
             F.col('prv_candidates.rb').cast('array<float>').alias('rb'),
             F.col('prv_candidates.nbad').cast('array<int>').alias('nbad')
         )
@@ -264,7 +265,7 @@ def main():
             "tmp",
             F.arrays_zip(
                 "magpsf", "sigmapsf", "diffmaglim", "jd", "fid",
-                "magnr", "sigmagnr", "isdiffpos",
+                "magnr", "sigmagnr", "isdiffpos", "distnr"
                 "rb", "nbad"
             )
         ).withColumn("tmp", F.explode("tmp")).select(
@@ -278,6 +279,7 @@ def main():
             F.col("tmp.magnr"),
             F.col("tmp.sigmagnr"),
             F.col("tmp.isdiffpos"),
+            F.col("tmp.distnr"),
             F.col("tmp.rb"),
             F.col("tmp.nbad")
         )

--- a/conf/fink.conf.dev
+++ b/conf/fink.conf.dev
@@ -46,7 +46,9 @@ FINK_PACKAGES=\
 org.apache.spark:spark-streaming-kafka-0-10-assembly_2.12:3.4.1,\
 org.apache.spark:spark-sql-kafka-0-10_2.12:3.4.1,\
 org.apache.spark:spark-avro_2.12:3.4.1,\
-org.apache.hbase:hbase-shaded-mapreduce:2.2.7
+org.apache.hbase:hbase-shaded-mapreduce:2.2.7\
+org.slf4j:slf4j-log4j12:1.7.36,\
+org.slf4j:slf4j-simple:1.7.36
 
 # Other dependencies (incl. Scala part of Fink)
 FINK_JARS=${FINK_HOME}/libs/fink-broker_2.11-1.2.jar,\

--- a/conf/fink.conf.dev
+++ b/conf/fink.conf.dev
@@ -46,7 +46,7 @@ FINK_PACKAGES=\
 org.apache.spark:spark-streaming-kafka-0-10-assembly_2.12:3.4.1,\
 org.apache.spark:spark-sql-kafka-0-10_2.12:3.4.1,\
 org.apache.spark:spark-avro_2.12:3.4.1,\
-org.apache.hbase:hbase-shaded-mapreduce:2.2.7\
+org.apache.hbase:hbase-shaded-mapreduce:2.2.7,\
 org.slf4j:slf4j-log4j12:1.7.36,\
 org.slf4j:slf4j-simple:1.7.36
 

--- a/conf/fink.conf.dev
+++ b/conf/fink.conf.dev
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 AstroLab Software
+# Copyright 2018-2024 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,11 +46,12 @@ FINK_PACKAGES=\
 org.apache.spark:spark-streaming-kafka-0-10-assembly_2.12:3.4.1,\
 org.apache.spark:spark-sql-kafka-0-10_2.12:3.4.1,\
 org.apache.spark:spark-avro_2.12:3.4.1,\
-org.apache.hbase:hbase-shaded-mapreduce:2.4.9
+org.apache.hbase:hbase-shaded-mapreduce:2.2.7
 
 # Other dependencies (incl. Scala part of Fink)
-FINK_JARS=${FINK_HOME}/libs/hbase-spark-hbase2.4.8_spark3.4.1_scala2.12.0_hadoop3.3.6.jar,\
-${FINK_HOME}/libs/hbase-spark-protocol-shaded-hbase2.4.8_spark3.4.1_scala2.12.0_hadoop3.3.6.jar
+FINK_JARS=${FINK_HOME}/libs/fink-broker_2.11-1.2.jar,\
+${FINK_HOME}/libs/hbase-spark-hbase2.3.0_spark3.4.1_scala2.12.0_hadoop3.3.6.jar,\
+${FINK_HOME}/libs/hbase-spark-protocol-shaded-hbase2.3.0_spark3.4.1_scala2.12.0_hadoop3.3.6.jar
 
 # Time interval between 2 trigger updates (second)
 # i.e. the timing of streaming data processing.

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -19,9 +19,9 @@ fastavro==1.6.0
 
 # Fink core
 fink_filters>=3.24
-git+https://github.com/astrolabsoftware/fink-science@5.6.1
-fink-utils>=0.13.8
-fink-spins>=0.3.5
+git+https://github.com/astrolabsoftware/fink-science@5.6.2
+fink-utils>=0.13.11
+fink-spins>=0.3.7
 fink-tns>=0.9
 
 # Misc


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #778 

## What changes were proposed in this pull request?

In this PR, we add necessary columns to reconstruct apparent magnitude for `uppervalid` alerts. 

We also optimise the way we push data to HBase by reducing the number of elements to push (**require** `fink-utils>=0.13.11`). Basically, we were pushing before all the history, no matter the history was unchanged from the point of view of `uppervalid` or `upper`. This was leading to redundant write night after night, and it was putting a lot of load in the database when writing million of elements unnecessarily.

Now the strategy is different. We first look in the history if the last element is `uppervalid` or `upper`, and only in this case, we push the history in the database. We could further optimise by looking at the corresponding history, and selecting only latest elements (by opposition to all elements), but this would complexify too much the analysis for a very moderate gain.

Here are some numbers for one night (`2024/01/04`, 237,104 alerts):

### uppervalid

| | old strategy | new strategy |
|-|-|-|
| # alert history to explode | 237,104 | 7,980 |
| # rows to push to HBase | 1,196,247 | 20,965 |

### upper

| | old strategy | new strategy |
|-|-|-|
| # alert history to explode | 237,104 | 165,810 |
| # rows to push to HBase | 2,804,673 | 2,168,893 |

### Conclusion

The number of elements to push for `uppervalid` is drastically smaller! This is why, we can afford more columns now. For `upper`, this number does not decrease much, because (1) the stream contains a lot of new objects each night (history full of upper limits), and (2) there are a lot of upper limits in between two valid measurements (this is probably where a more complex analysis would reduce the number of write -- but that's for later, maybe).

## How was this patch tested?

Cloud & CI
