### PR TITLE
Update Slack channel names

### DIFF
--- a/bin/anomaly_archival.py
+++ b/bin/anomaly_archival.py
@@ -63,7 +63,7 @@ def main():
     pdf = anomaly_notification_(
         df_proc, threshold=10,
         send_to_tg=True, channel_id="@ZTF_anomaly_bot",
-        send_to_slack=True, channel_name='anomaly_bot'
+        send_to_slack=True, channel_name='bot_anomaly'
     )
 
     # Area-restricted anomalies
@@ -71,7 +71,7 @@ def main():
     anomaly_notification_(
         df_proc, threshold=5,
         send_to_tg=True, channel_id='@anomaly_spec',
-        send_to_slack=False, channel_name=None,
+        send_to_slack=True, channel_name='bot_anomaly_area',
         cut_coords=True
     )
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): 
- Closes #788 
- Closes #786 

## What changes were proposed in this pull request?

Slack channel names for the anomaly bot have been updated. And now we also send data on Slack for the area-restricted anomaly bot.

## How was this patch tested?

Cloud