### PR TITLE
Add crossmatch with the SPICY catalog

### DIFF
--- a/fink_broker/hbaseUtils.py
+++ b/fink_broker/hbaseUtils.py
@@ -44,7 +44,7 @@ def load_fink_cols():
     --------
     >>> fink_cols, fink_nested_cols = load_fink_cols()
     >>> print(len(fink_cols))
-    27
+    29
 
     >>> print(len(fink_nested_cols))
     18
@@ -109,7 +109,7 @@ def load_all_cols():
     >>> root_level, candidates, images, fink_cols, fink_nested_cols = load_all_cols()
     >>> out = {**root_level, **candidates, **images, **fink_cols, **fink_nested_cols}
     >>> print(len(out))
-    156
+    158
     """
     fink_cols, fink_nested_cols = load_fink_cols()
 
@@ -320,7 +320,7 @@ def load_ztf_index_cols():
     --------
     >>> out = load_ztf_index_cols()
     >>> print(len(out))
-    81
+    83
     """
     # From `root` or `candidates.`
     common = [

--- a/fink_broker/hbaseUtils.py
+++ b/fink_broker/hbaseUtils.py
@@ -77,6 +77,8 @@ def load_fink_cols():
         'upper_rate': {'type': 'double', 'default': 0.0},
         'delta_time': {'type': 'double', 'default': 0.0},
         'from_upper': {'type': 'boolean', 'default': False},
+        'spicy_id': {'type': 'int', 'default': -1},
+        'spicy_name': {'type': 'string', 'default': 'Unknown'},
     }
 
     fink_nested_cols = {}

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -245,6 +245,18 @@ def apply_science_modules(df: DataFrame, noscience: bool = False) -> DataFrame:
     # see https://github.com/astrolabsoftware/fink-broker/issues/787
     df = df.withColumnRenamed('Type', 'vsx')
 
+    _LOG.info("New processor: SPICY (1.2 arcsec)")
+    df = xmatch_cds(
+        df,
+        catalogname="vizier:J/ApJS/254/33/table1",
+        distmaxarcsec=1.2,
+        cols_out=['SPICY', 'class'],
+        types=['int', 'string']
+    )
+    # rename `SPICY` into `spicy_id` and `class` into `spicy_class`
+    df = df.withColumnRenamed('SPICY', 'spicy_id')
+    df = df.withColumnRenamed('class', 'spicy_class')
+
     _LOG.info("New processor: GCVS (1.5 arcsec)")
     df = df.withColumn(
         'gcvs',

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -257,11 +257,11 @@ def apply_science_modules(df: DataFrame, noscience: bool = False) -> DataFrame:
     df = df.withColumnRenamed('SPICY', 'spicy_id')
     # Cast null into -1
     df = df.withColumn(
-        'SPICY',
+        'spicy_id',
         F.when(
-            df['SPICY'].isNull(),
+            df['spicy_id'].isNull(),
             F.lit(-1)
-        ).otherwise(df['SPICY'])
+        ).otherwise(df['spicy_id'])
     )
 
     # rename `class` into `spicy_class`. Values are:

--- a/fink_broker/science.py
+++ b/fink_broker/science.py
@@ -253,9 +253,28 @@ def apply_science_modules(df: DataFrame, noscience: bool = False) -> DataFrame:
         cols_out=['SPICY', 'class'],
         types=['int', 'string']
     )
-    # rename `SPICY` into `spicy_id` and `class` into `spicy_class`
+    # rename `SPICY` into `spicy_id`. Values are number or null
     df = df.withColumnRenamed('SPICY', 'spicy_id')
+    # Cast null into -1
+    df = df.withColumn(
+        'SPICY',
+        F.when(
+            df['SPICY'].isNull(),
+            F.lit(-1)
+        ).otherwise(df['SPICY'])
+    )
+
+    # rename `class` into `spicy_class`. Values are:
+    # Unknown, FS, ClassI, ClassII, ClassIII, or 'nan'
     df = df.withColumnRenamed('class', 'spicy_class')
+    # Make 'nan' 'Unknown'
+    df = df.withColumn(
+        'spicy_class',
+        F.when(
+            df['spicy_class'] == 'nan',
+            F.lit('Unknown')
+        ).otherwise(df['spicy_class'])
+    )
 
     _LOG.info("New processor: GCVS (1.5 arcsec)")
     df = df.withColumn(


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #800 

## What changes were proposed in this pull request?

This PR adds a new science module that crossmatches alerts with the SPICY catalog hosted at CDS. We extracted two fields from the catalog: `SPICY`, and `class`. Those fields are renamed into `spicy_id` (integer), and `spicy_name` (string). Default values are `-1` and `Unknown` respectively.

## How was this patch tested?

Cloud.