### PR TITLE
Bump fink-science to 5.7.1, with the memory leak fixed

### DIFF
--- a/deps/requirements-science.txt
+++ b/deps/requirements-science.txt
@@ -27,7 +27,6 @@ tensorflow==2.9.2
 tensorflow_addons==0.18.0
 
 # Anomalies
-onnx==1.12.0
 onnxruntime
 
 # fink-fat

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -19,7 +19,7 @@ fastavro==1.6.0
 
 # Fink core
 fink_filters>=3.24
-git+https://github.com/astrolabsoftware/fink-science@5.6.2
+git+https://github.com/astrolabsoftware/fink-science@5.7.1
 fink-utils>=0.13.11
 fink-spins>=0.3.7
 fink-tns>=0.9


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #809 

## What changes were proposed in this pull request?

This PR uses fink-science 5.7.1, that fixes a memory leak in a science module.

## How was this patch tested?

CI
