### PR TITLE
Add a new option to control the number of offsets per trigger 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,6 @@ jobs:
     - name: Run test suites [dev]
       if: matrix.container == 'julienpeloton/fink-ci:dev'
       run: |
-        # TODO: remove me
-        pip install fink-utils==0.13.11
         cd $USRLIBS
         source scripts/start_services.sh --kafka-version ${KAFKA_VERSION} --hbase-version ${HBASE_VERSION}
         cd $FINK_HOME

--- a/bin/distribute.py
+++ b/bin/distribute.py
@@ -46,7 +46,8 @@ userfilters = [
     'fink_filters.filter_microlensing_candidates.filter.microlensing_candidates',
     'fink_filters.filter_yso_candidates.filter.yso_candidates',
     'fink_filters.filter_simbad_grav_candidates.filter.simbad_grav_candidates',
-    'fink_filters.filter_blazar.filter.blazar'
+    'fink_filters.filter_blazar.filter.blazar',
+    'fink_filters.filter_yso_spicy_candidates.filter.yso_spicy_candidates'
 ]
 
 def main():
@@ -100,7 +101,7 @@ def main():
     # Retrieve time-series information
     to_expand = [
         'jd', 'fid', 'magpsf', 'sigmapsf',
-        'magnr', 'sigmagnr', 'magzpsci', 'isdiffpos'
+        'magnr', 'sigmagnr', 'magzpsci', 'isdiffpos', 'diffmaglim'
     ]
 
     # Append temp columns with historical + current measurements

--- a/bin/distribute.py
+++ b/bin/distribute.py
@@ -112,6 +112,8 @@ def main():
     for colname in to_expand:
         df = df.withColumnRenamed('c' + colname, 'c' + colname + 'c')
 
+    df = df.withColumn('cstampDatac', df["cutoutScience.stampData"])
+
     broker_list = args.distribution_servers
     for userfilter in userfilters:
         # The topic name is the filter name

--- a/bin/fink
+++ b/bin/fink
@@ -257,6 +257,7 @@ elif [[ $service == "stream2raw" ]]; then
     ${SECURED_KAFKA_CONFIG} ${EXTRA_SPARK_CONFIG} \
     ${FINK_HOME}/bin/stream2raw.py ${HELP_ON_SERVICE} -producer ${PRODUCER} -servers ${KAFKA_IPPORT} -topic ${KAFKA_TOPIC} \
     -schema ${FINK_ALERT_SCHEMA} -startingoffsets_stream ${KAFKA_STARTING_OFFSET} \
+    -max_offsets_per_trigger ${MAX_OFFSETS_PER_TRIGGER} \
     -online_data_prefix ${ONLINE_DATA_PREFIX} \
     -tinterval ${FINK_TRIGGER_UPDATE} -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "raw2science" ]]; then

--- a/bin/stream2raw.py
+++ b/bin/stream2raw.py
@@ -68,6 +68,7 @@ def main():
         servers=args.servers,
         topic=args.topic,
         startingoffsets=args.startingoffsets_stream,
+        max_offsets_per_trigger=args.max_offsets_per_trigger,
         failondataloss=False,
         kerberos=False)
 

--- a/conf/fink.conf
+++ b/conf/fink.conf
@@ -61,6 +61,7 @@ ${FINK_HOME}/libs/hbase-spark-protocol-shaded-1.0.1-SNAPSHOT.jar
 # Note that this timing is also used for updating the dashboard.
 FINK_TRIGGER_UPDATE=2
 
+
 # Alert schema
 # Full path to schema to decode the alerts
 FINK_ALERT_SCHEMA=${FINK_HOME}/schemas/template_schema_ZTF_3p3.avro

--- a/conf/fink.conf.cluster
+++ b/conf/fink.conf.cluster
@@ -57,6 +57,7 @@ ${FINK_HOME}/libs/hbase-spark-protocol-shaded-1.0.1-SNAPSHOT.jar
 # micro-batch has completed processing.
 # Note that this timing is also used for updating the dashboard.
 FINK_TRIGGER_UPDATE=2
+MAX_OFFSETS_PER_TRIGGER=5000
 
 # Alert schema
 # Full path to schema to decode the alerts

--- a/conf/fink.conf.dev
+++ b/conf/fink.conf.dev
@@ -62,6 +62,7 @@ ${FINK_HOME}/libs/hbase-spark-protocol-shaded-hbase2.3.0_spark3.4.1_scala2.12.0_
 # micro-batch has completed processing.
 # Note that this timing is also used for updating the dashboard.
 FINK_TRIGGER_UPDATE=2
+MAX_OFFSETS_PER_TRIGGER=5000
 
 # Alert schema
 # Full path to schema to decode the alerts

--- a/conf/fink.conf.prod
+++ b/conf/fink.conf.prod
@@ -61,6 +61,7 @@ ${FINK_HOME}/libs/hbase-spark-protocol-shaded-hbase2.3.0_spark3.4.1_scala2.12.0_
 # micro-batch has completed processing.
 # Note that this timing is also used for updating the dashboard.
 FINK_TRIGGER_UPDATE=2
+MAX_OFFSETS_PER_TRIGGER=5000
 
 # Alert schema
 # Full path to schema to decode the alerts

--- a/deps/requirements-science.txt
+++ b/deps/requirements-science.txt
@@ -14,7 +14,7 @@ colorama
 seaborn
 
 # SNAD
-light-curve[full]
+light-curve[full]==0.8.2
 
 # AGN
 iminuit==2.21.0

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -18,7 +18,7 @@ avro-python3
 fastavro==1.6.0
 
 # Fink core
-fink_filters>=3.25
+fink_filters>=3.26
 git+https://github.com/astrolabsoftware/fink-science@5.7.1
 fink-utils>=0.17.5
 fink-spins>=0.3.7

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -18,9 +18,9 @@ avro-python3
 fastavro==1.6.0
 
 # Fink core
-fink_filters>=3.24
+fink_filters>=3.25
 git+https://github.com/astrolabsoftware/fink-science@5.7.1
-fink-utils>=0.13.11
+fink-utils>=0.17.5
 fink-spins>=0.3.7
 fink-tns>=0.9
 

--- a/e2e/check-results.sh
+++ b/e2e/check-results.sh
@@ -30,7 +30,7 @@ DIR=$(cd "$(dirname "$0")"; pwd -P)
 # for example in finkctl.yaml
 if [ "$SUFFIX" = "noscience" ];
 then
-  expected_topics="11"
+  expected_topics="12"
 else
   expected_topics="1"
 fi

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -59,6 +59,12 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         building the raw database: latest, earliest, or custom.
         [KAFKA_STARTING_OFFSET]
         """)
+     parser.add_argument(
+        '-max_offsets_per_trigger', type=int, default=5000,
+        help="""Maximum number of offsets to fetch per trigger.
+        Default is 5000.
+        [MAX_OFFSETS_PER_TRIGGER]
+        """)
     parser.add_argument(
         '-online_data_prefix', type=str, default='',
         help="""Path prefix to store online data, e.g. /path/to/online.

--- a/fink_broker/parser.py
+++ b/fink_broker/parser.py
@@ -59,7 +59,7 @@ def getargs(parser: argparse.ArgumentParser) -> argparse.Namespace:
         building the raw database: latest, earliest, or custom.
         [KAFKA_STARTING_OFFSET]
         """)
-     parser.add_argument(
+    parser.add_argument(
         '-max_offsets_per_trigger', type=int, default=5000,
         help="""Maximum number of offsets to fetch per trigger.
         Default is 5000.

--- a/fink_broker/sparkUtils.py
+++ b/fink_broker/sparkUtils.py
@@ -209,6 +209,7 @@ def get_spark_context() -> SparkContext:
 def connect_to_kafka(
         servers: str, topic: str,
         startingoffsets: str = "latest",
+        max_offsets_per_trigger: int = 5000,
         failondataloss: bool = False, kerberos: bool = False) -> DataFrame:
     """ Initialise SparkSession, and set default Kafka parameters
 
@@ -223,6 +224,8 @@ def connect_to_kafka(
         latest (only new data), earliest (connect from the oldest
         offset available), or a number (see Spark Kafka integration).
         Default is latest.
+    max_offsets_per_trigger: int, optional
+        Maximum number of offsets to fetch per trigger. Default is 5,000.
     failondataloss: bool, optional
         If True, Spark streaming job will fail if it is asking for data offsets
         that do not exist anymore in Kafka (because they have been deleted after
@@ -250,7 +253,8 @@ def connect_to_kafka(
     df = spark \
         .readStream \
         .format("kafka") \
-        .option("kafka.bootstrap.servers", servers)
+        .option("kafka.bootstrap.servers", servers) \
+        .option("maxOffsetsPerTrigger", max_offsets_per_trigger)
 
     if kerberos:
         df = df.option(


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #819 

## What changes were proposed in this pull request?

Mistakenly pushed to the master branch, reverted, and pushed in this PR. There is now a new option to control the number of offsets to pull per trigger (Spark Kafka connector). The default is 5000.

## How was this patch tested?

CI