### PR TITLE
Do not filter alerts containing i-band only in the history

### DIFF
--- a/bin/raw2science.py
+++ b/bin/raw2science.py
@@ -161,9 +161,7 @@ def main():
         df = df.filter(df["candidate.nbad"] == 0).filter(df["candidate.rb"] >= 0.55)
 
         # Discard an alert if it is in i band
-        # or if it contains i band measurements in history
         df = df.filter(df["candidate.fid"] != 3)
-        df = df.filter(~F.array_contains(df["prv_candidates.fid"], 3))
 
         # Apply science modules
         _LOG.info("Applying science modules")


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #854 

## What changes were proposed in this pull request?

Only filter alerts taken in `i` band, but let entering alerts taken in `g` & `r` with `i` band in the history. 

Note that we do not have a test set here with `i` band. Science modules have been tested in https://github.com/astrolabsoftware/fink-science/pull/394, but database operations have not been tested.

## How was this patch tested?

Cloud.