### PR TITLE
Fix column name when constructing the rowkey

### DIFF
--- a/bin/anomaly_archival.py
+++ b/bin/anomaly_archival.py
@@ -87,9 +87,7 @@ def main():
 
     # Row key
     row_key_name = "jd_objectId"
-    df_hbase = add_row_key(
-        df_hbase, row_key_name=row_key_name, cols=["jd", "objectId"]
-    )
+    df_hbase = add_row_key(df_hbase, row_key_name=row_key_name, cols=["jd", "objectId"])
 
     # push data to HBase
     push_full_df_to_hbase(

--- a/bin/anomaly_archival.py
+++ b/bin/anomaly_archival.py
@@ -88,7 +88,7 @@ def main():
     # Row key
     row_key_name = "jd_objectId"
     df_hbase = add_row_key(
-        df_hbase, row_key_name=row_key_name, cols=["candidate.jd", "objectId"]
+        df_hbase, row_key_name=row_key_name, cols=["jd", "objectId"]
     )
 
     # push data to HBase


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #863 

## What changes were proposed in this pull request?

The column name `candidate.jd` is renamed `jd` after selection.

## How was this patch tested?

Cloud.