### PR TITLE
Add script to detect hostless candidates

### DIFF
--- a/bin/active_learning_loop.py
+++ b/bin/active_learning_loop.py
@@ -122,7 +122,7 @@ def main():
 
     # model path
     curdir = os.path.dirname(os.path.abspath(__file__))
-    model = curdir + "/data/models/for_al_loop/model_20240422.pkl"
+    model = curdir + "/data/models/for_al_loop/model_20240729.pkl"
 
     # Run SN classification using AL model
     rfscore_args = ["cjd", "cfid", "cmagpsf", "csigmapsf"]

--- a/bin/fink
+++ b/bin/fink
@@ -483,6 +483,14 @@ elif [[ $service == "al_loop" ]]; then
   -agg_data_prefix ${AGG_DATA_PREFIX} \
   -night ${NIGHT} \
   -log_level ${LOG_LEVEL} ${EXIT_AFTER}
+elif [[ $service == "hostless" ]]; then
+  spark-submit --master ${SPARK_MASTER} \
+  --packages ${FINK_PACKAGES} \
+  --jars ${FINK_JARS} ${PYTHON_EXTRA_FILE} ${EXTRA_SPARK_CONFIG} \
+  ${FINK_HOME}/bin/hostless_detection.py ${HELP_ON_SERVICE} \
+  -agg_data_prefix ${AGG_DATA_PREFIX} \
+  -night ${NIGHT} \
+  -log_level ${LOG_LEVEL} ${EXIT_AFTER}
 elif [[ $service == "dwarf_agn" ]]; then
   spark-submit --master ${SPARK_MASTER} \
   --packages ${FINK_PACKAGES} \

--- a/bin/hostless_detection.py
+++ b/bin/hostless_detection.py
@@ -100,6 +100,7 @@ def main():
             df["rf_kn_vs_nonkn"],
             df["finkclass"],
             df["tnsclass"],
+            df["candidate.jd"] - df["candidate.jdstarthist"],
         ),
     )
 

--- a/bin/hostless_detection.py
+++ b/bin/hostless_detection.py
@@ -23,7 +23,6 @@ import numpy as np
 from pyspark.sql import functions as F
 
 from fink_utils.spark.utils import concat_col
-from fink_utils.xmatch.simbad import return_list_of_eg_host
 
 from fink_broker.parser import getargs
 from fink_broker.spark_utils import init_sparksession, load_parquet_files
@@ -149,6 +148,9 @@ def main():
     ]
 
     pdf = df.filter(df["kstest_static"] >= 0).select(cols_).toPandas()
+
+    # log the number of candidates
+    # sort by score
 
     init_msg = f"Number of candidates for the night {args.night}: {len(pdf)} ({len(np.unique(pdf.objectId))} unique objects)."
 

--- a/bin/hostless_detection.py
+++ b/bin/hostless_detection.py
@@ -18,7 +18,6 @@
 import argparse
 import os
 
-import numpy as np
 
 from pyspark.sql import functions as F
 
@@ -34,7 +33,6 @@ from fink_utils.tg_bot.utils import get_curve
 from fink_utils.tg_bot.utils import get_cutout
 from fink_utils.tg_bot.utils import msg_handler_tg_cutouts
 
-from fink_science import __file__
 from fink_science.hostless_detection.processor import run_potential_hostless
 
 
@@ -113,7 +111,7 @@ def main():
         "finkclass",
         "tnsclass",
         F.col("cutoutScience.stampData").alias("cutoutScience"),
-        F.col("cutoutTemplate.stampData").alias("cutoutTemplate")
+        F.col("cutoutTemplate.stampData").alias("cutoutTemplate"),
     ]
 
     cond_science = df["kstest_static"][0] >= 0

--- a/bin/hostless_detection.py
+++ b/bin/hostless_detection.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+# Copyright 2023-2024 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Run the hostless detection module, and push data to Slack/Telegram."""
+
+import argparse
+import os
+
+import numpy as np
+
+from pyspark.sql import functions as F
+
+from fink_utils.spark.utils import concat_col
+from fink_utils.xmatch.simbad import return_list_of_eg_host
+
+from fink_broker.parser import getargs
+from fink_broker.spark_utils import init_sparksession, load_parquet_files
+from fink_broker.logging_utils import get_fink_logger, inspect_application
+
+from fink_filters.classification import extract_fink_classification
+from fink_filters.filter_anomaly_notification.filter_utils import msg_handler_slack
+from fink_filters.filter_anomaly_notification.filter_utils import (
+    get_data_permalink_slack,
+)
+
+from fink_science import __file__
+from fink_science.hostless_detection.processor import run_potential_hostless
+
+
+def append_slack_messages(slack_data: list, row: dict) -> None:
+    """Append messages to list for Slack distribution.
+
+    Parameters
+    ----------
+    slack_data: list
+        List containing all Slack messages. Each element
+        is a message (string).
+    row: dict
+        Pandas DataFrame row as dictionary. Contains
+        Fink data.
+    """
+    t1 = f"ID: <https://fink-portal.org/{row.objectId}|{row.objectId}>"
+    t2 = f"""
+EQU: {row.ra},   {row.dec}"""
+
+    t3 = f"Score: {round(row.kstest_static, 3)}"
+    t4 = f"Fink classification: {row.finkclass}"
+    cutout, curve, cutout_perml, curve_perml = get_data_permalink_slack(row.objectId)
+    curve.seek(0)
+    cutout.seek(0)
+    cutout_perml = f"<{cutout_perml}|{' '}>"
+    curve_perml = f"<{curve_perml}|{' '}>"
+    slack_data.append(
+        f"""==========================
+{t1}
+{t2}
+{t3}
+{t4}
+{cutout_perml}{curve_perml}"""
+    )
+
+
+def main():
+    """Extract probabilities from the hostless detection module, and send results to Slack."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = getargs(parser)
+
+    # Initialise Spark session
+    spark = init_sparksession(
+        name="hostless_{}".format(args.night), shuffle_partitions=2
+    )
+
+    # The level here should be controlled by an argument.
+    logger = get_fink_logger(spark.sparkContext.appName, args.log_level)
+
+    # debug statements
+    inspect_application(logger)
+
+    # Connect to the aggregated science database
+    path = "{}/science/year={}/month={}/day={}".format(
+        args.agg_data_prefix, args.night[:4], args.night[4:6], args.night[6:8]
+    )
+    df = load_parquet_files(path)
+
+    # Retrieve time-series information
+    to_expand = ["magpsf"]
+
+    # Append temp columns with historical + current measurements
+    prefix = "c"
+    for colname in to_expand:
+        df = concat_col(df, colname, prefix=prefix)
+
+    # Add classification
+    cols = [
+        "cdsxmatch",
+        "roid",
+        "mulens",
+        "snn_snia_vs_nonia",
+        "snn_sn_vs_all",
+        "rf_snia_vs_nonia",
+        "candidate.ndethist",
+        "candidate.drb",
+        "candidate.classtar",
+        "candidate.jd",
+        "candidate.jdstarthist",
+        "rf_kn_vs_nonkn",
+        "tracklet",
+    ]
+    df = df.withColumn("finkclass", extract_fink_classification(*cols))
+
+    # Add TNS classification -- fake for the moment
+    df = df.withColumn("tnsclass", F.lit("Unknown"))
+
+    # Add a new column
+    df = df.withColumn(
+        "kstest_static",
+        run_potential_hostless(
+            df["cmagpsf"],
+            df["cutoutScience.stampData"],
+            df["cutoutTemplate.stampData"],
+            df["snn_snia_vs_nonia"],
+            df["snn_sn_vs_all"],
+            df["rf_snia_vs_nonia"],
+            df["rf_kn_vs_nonkn"],
+            df["finkclass"],
+            df["tnsclass"],
+        ),
+    )
+
+    cols_ = [
+        "objectId",
+        "candidate.ra",
+        "candidate.dec",
+        "kstest_static",
+        "finkclass",
+        "tnsclass",
+    ]
+
+    pdf = df.filter(df["kstest_static"] >= 0).select(cols_).toPandas()
+
+    init_msg = f"Number of candidates for the night {args.night}: {len(pdf)} ({len(np.unique(pdf.objectId))} unique objects)."
+
+    slack_data = []
+    # limit to the first 100th (guard against processing error)
+    for _, row in pdf.head(30).iterrows():
+        append_slack_messages(slack_data, row)
+
+    msg_handler_slack(slack_data, "bot_hostless", init_msg)
+
+
+if __name__ == "__main__":
+    main()

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -20,7 +20,7 @@ fastavro==1.6.0
 # Fink core
 fink_filters>=3.32
 git+https://github.com/astrolabsoftware/fink-science@5.13.0
-fink-utils>=0.17.5
+fink-utils>=0.18.0
 fink-spins>=0.3.7
 fink-tns>=0.9
 

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -18,8 +18,8 @@ avro-python3
 fastavro==1.6.0
 
 # Fink core
-fink_filters>=3.30
-git+https://github.com/astrolabsoftware/fink-science@5.8.1
+fink_filters>=3.32
+git+https://github.com/astrolabsoftware/fink-science@5.13.0
 fink-utils>=0.17.5
 fink-spins>=0.3.7
 fink-tns>=0.9

--- a/scheduler/database_auxilliary.sh
+++ b/scheduler/database_auxilliary.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2024 AstroLab Software
+# Author: Julien Peloton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+source ~/.bash_profile
+
+NIGHT=`date +"%Y%m%d"`
+YEAR=${NIGHT:0:4}
+MONTH=${NIGHT:4:2}
+DAY=${NIGHT:6:2}
+
+$(hdfs dfs -test -d /user/julien.peloton/archive/science/year=${YEAR}/month=${MONTH}/day=${DAY})
+if [[ $? == 0 ]]; then
+    echo "Push TNS candidates"
+    fink start push_to_tns -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --tns_folder ${FINK_HOME}/tns_logs > ${FINK_HOME}/broker_logs/tns_${NIGHT}.log 2>&1
+
+    echo "Push Anomaly candidates"
+    fink start anomaly_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/anomaly_detection_${NIGHT}.log 2>&1
+
+    echo "Push Active Learning loop candidates"
+    fink start al_loop -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/al_loop_${NIGHT}.log 2>&1
+
+    echo "Push Hostless candidates"
+    fink start hostless -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/hostless_${NIGHT}.log 2>&1
+
+    echo "Send Dwarf AGN candidates"
+    fink start dwarf_agn -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/dwarf_agn_${NIGHT}.log 2>&1
+
+    echo "Update statistics"
+    fink start stats -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/stats_${NIGHT}.log 2>&1
+
+    echo "Call to Fink-Fat"
+    fink_fat associations candidates --config $FINK_HOME/conf/fink_fat.conf --night ${YEAR}-${MONTH}-${DAY} --verbose > ${FINK_HOME}/broker_logs/fink_fat_association_${NIGHT}.log 2>&1
+    fink_fat solve_orbit candidates local --config $FINK_HOME/conf/fink_fat.conf --verbose > ${FINK_HOME}/broker_logs/fink_fat_solve_orbit_${NIGHT}.log 2>&1
+
+    echo "Push SSO candidates to HBase"
+    fink start index_sso_cand_archival -c $FINK_HOME/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/index_sso_cand_archival_${NIGHT}.log 2>&1
+
+fi
+

--- a/scheduler/database_service.sh
+++ b/scheduler/database_service.sh
@@ -41,34 +41,6 @@ if [[ $? == 0 ]]; then
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table tracklet_objectId > ${FINK_HOME}/broker_logs/index_tracklet_objectId_${NIGHT}.log 2>&1
     fink start index_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --index_table tns_jd_objectId --tns_folder ${FINK_HOME}/tns_logs > ${FINK_HOME}/broker_logs/index_tns_jd_objectId_${NIGHT}.log 2>&1
 
-    # echo "Push object tables to HBase"
-    # fink start object_archival -c $FINK_HOME/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/object_archival_${NIGHT}.log 2>&1
-
-    echo "Push TNS candidates"
-    fink start push_to_tns -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} --tns_folder ${FINK_HOME}/tns_logs > ${FINK_HOME}/broker_logs/tns_${NIGHT}.log 2>&1
-
-    echo "Push Anomaly candidates"
-    fink start anomaly_archival -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/anomaly_detection_${NIGHT}.log 2>&1
-
-    echo "Push Active Learning loop candidates"
-    fink start al_loop -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/al_loop_${NIGHT}.log 2>&1
-
-    echo "Push Hostless candidates"
-    fink start hostless -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/hostless_${NIGHT}.log 2>&1
-
-    echo "Send Dwarf AGN candidates"
-    fink start dwarf_agn -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/dwarf_agn_${NIGHT}.log 2>&1
-
-    echo "Update statistics"
-    fink start stats -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/stats_${NIGHT}.log 2>&1
-
-    echo "Call to Fink-Fat"
-    fink_fat associations candidates --config $FINK_HOME/conf/fink_fat.conf --night ${YEAR}-${MONTH}-${DAY} --verbose > ${FINK_HOME}/broker_logs/fink_fat_association_${NIGHT}.log 2>&1
-    fink_fat solve_orbit candidates local --config $FINK_HOME/conf/fink_fat.conf --verbose > ${FINK_HOME}/broker_logs/fink_fat_solve_orbit_${NIGHT}.log 2>&1
-
-    echo "Push SSO candidates to HBase"
-    fink start index_sso_cand_archival -c $FINK_HOME/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/index_sso_cand_archival_${NIGHT}.log 2>&1
-
 fi
 
 # Check if data is on the archive

--- a/scheduler/database_service.sh
+++ b/scheduler/database_service.sh
@@ -53,6 +53,9 @@ if [[ $? == 0 ]]; then
     echo "Push Active Learning loop candidates"
     fink start al_loop -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/al_loop_${NIGHT}.log 2>&1
 
+    echo "Push Hostless candidates"
+    fink start hostless -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/hostless_${NIGHT}.log 2>&1
+
     echo "Send Dwarf AGN candidates"
     fink start dwarf_agn -c ${FINK_HOME}/conf_cluster/fink.conf.ztf_nomonitoring_hbase --night ${NIGHT} > ${FINK_HOME}/broker_logs/dwarf_agn_${NIGHT}.log 2>&1
 


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #867 

## What changes were proposed in this pull request?

Add a new operation to detect hostless transients (https://arxiv.org/abs/2404.18165):
- [x] Add a new script to launch the processing at the end of the night
- [ ] Perform cross-match with TNS
- [x] Send data to Slack
- [x] Send data to Telegram

Note that as the module is operated at the end of the night, neither alert packets nor HBase get the information. We might want to change this in the future, and make a real-time module.

## How was this patch tested?

Cloud, CI, profiling