### PR TITLE
Include lower bounds when filtering for hostless

### DIFF
--- a/bin/hostless_detection.py
+++ b/bin/hostless_detection.py
@@ -117,9 +117,16 @@ def main():
         F.col("cutoutTemplate.stampData").alias("cutoutTemplate"),
     ]
 
-    cond_science = df["kstest_static"][0] <= 0.5
-    cond_template = df["kstest_static"][1] <= 0.85
-    pdf = df.filter(cond_science).filter(cond_template).select(cols_).toPandas()
+    cond_science_low = df["kstest_static"][0] >= 0.
+    cond_science_high = df["kstest_static"][0] <= 0.5
+    cond_template_low = df["kstest_static"][1] >= 0.
+    cond_template_high = df["kstest_static"][1] <= 0.85
+
+    pdf = df\
+        .filter(cond_science_low & cond_science_high)\
+        .filter(cond_template_low & cond_template_high)\
+        .select(cols_)\
+        .toPandas()
 
     # load hostless IDs
     past_ids = read_past_ids(args.hostless_folder)

--- a/bin/hostless_detection.py
+++ b/bin/hostless_detection.py
@@ -117,16 +117,17 @@ def main():
         F.col("cutoutTemplate.stampData").alias("cutoutTemplate"),
     ]
 
-    cond_science_low = df["kstest_static"][0] >= 0.
+    cond_science_low = df["kstest_static"][0] >= 0.0
     cond_science_high = df["kstest_static"][0] <= 0.5
-    cond_template_low = df["kstest_static"][1] >= 0.
+    cond_template_low = df["kstest_static"][1] >= 0.0
     cond_template_high = df["kstest_static"][1] <= 0.85
 
-    pdf = df\
-        .filter(cond_science_low & cond_science_high)\
-        .filter(cond_template_low & cond_template_high)\
-        .select(cols_)\
+    pdf = (
+        df.filter(cond_science_low & cond_science_high)
+        .filter(cond_template_low & cond_template_high)
+        .select(cols_)
         .toPandas()
+    )
 
     # load hostless IDs
     past_ids = read_past_ids(args.hostless_folder)


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #904 

## What changes were proposed in this pull request?

Filtering for hostless candidates was missing lower bounds.

## How was this patch tested?

Cloud
