### PR TITLE
Set the topic number to 8 for science in the CI

### DIFF
--- a/e2e/check-results.sh
+++ b/e2e/check-results.sh
@@ -30,7 +30,7 @@ if [ "$SUFFIX" = "noscience" ];
 then
   expected_topics="13"
 else
-  expected_topics="9"
+  expected_topics="8"
 fi
 
 count=0


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #917 

## What changes were proposed in this pull request?

Set the expected number of topics to 8, and not 9, because one filter is expected to produce 0 alerts.

## How was this patch tested?

CI