### PR TITLE
Send JMX metrics to prometheus

### DIFF
--- a/.ciux
+++ b/.ciux
@@ -34,7 +34,7 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/spark-py:k8s-3.4.1
     labels:
       build: "true"
-  - package: github.com/k8s-school/ktbx@v1.1.4-rc4
+  - package: github.com/k8s-school/ktbx@v1.1.4-rc5
     labels:
       itest: "optional"
   - package: github.com/astrolabsoftware/finkctl/v3@v3.2.0-rc0

--- a/.github/workflows/e2e-common.yml
+++ b/.github/workflows/e2e-common.yml
@@ -24,11 +24,12 @@ on:
       registry_token:
         required: true
 env:
-  CIUX_VERSION: v0.0.4-rc10
+  CIUX_VERSION: v0.0.5-rc0
   GHA_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   SUFFIX: ${{ inputs.suffix }}
   CI_REPO: ${{ inputs.ci_repo }}
   STORAGE: ${{ inputs.storage }}
+  MONITORING_OPT: "-m"
   # Override the self-hosted runner value
   POD_NAMESPACE: default
 jobs:
@@ -121,7 +122,7 @@ jobs:
           # Configure private registry if needed
           ./e2e/kind-config.sh -r "${{ env.CI_REPO }}"
           # v0.20.0 does not work on self-hosted runners
-          ./e2e/prereq-install.sh -k "${{ inputs.kind_version }}"
+          ./e2e/prereq-install.sh -k "${{ inputs.kind_version }}" ${{ env.MONITORING_OPT}}
       - name: Download image
         uses: actions/download-artifact@v4
         with:
@@ -144,7 +145,7 @@ jobs:
       #     detached: true
       - name: Run argoCD
         run: |
-          ./e2e/argocd.sh -S "${{ matrix.storage }}"
+          ./e2e/argocd.sh -S "${{ matrix.storage }}" ${{ env.MONITORING_OPT}}
       - name: Check results
         run: |
           ./e2e/check-results.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,19 @@ RUN xargs -n 1 curl --fail --output-dir /opt/spark/jars -O < $FINK_HOME/jars-url
 ENV HOME /home/fink
 RUN mkdir $HOME && chown ${spark_uid} $HOME
 
+# Setup for the Prometheus JMX exporter.
+# TODO:
+# 1. check
+# jmx_prometheus_javaagent-1.0.1.jar.asc            2024-05-31 03:50       833
+# jmx_prometheus_javaagent-1.0.1.jar.md5            2024-05-31 03:50        32
+# jmx_prometheus_javaagent-1.0.1.jar.sha1           2024-05-31 03:50        40
+# 2. add the jar to the spark_py_image once dev is finished
+# Add the Prometheus JMX exporter Java agent jar for exposing metrics sent to the JmxSink to Prometheus.
+# 3. Update the version of the JMX exporter agent if needed to v1.0.1 (latest)
+ENV JMX_EXPORTER_AGENT_VERSION 1.1.0
+ADD https://github.com/prometheus/jmx_exporter/releases/download/${JMX_EXPORTER_AGENT_VERSION}/jmx_prometheus_javaagent-${JMX_EXPORTER_AGENT_VERSION}.jar /opt/spark/jars
+RUN chmod 644 /opt/spark/jars/jmx_prometheus_javaagent-${JMX_EXPORTER_AGENT_VERSION}.jar
+
 USER ${spark_uid}
 
 WORKDIR $HOME

--- a/TODO.931
+++ b/TODO.931
@@ -1,0 +1,3 @@
+Downgrade JMX experter w.r.t spark doc and test dashboard: 7890
+
+C'est quoi: https://github.com/monitoring-mixins/website/blob/master/assets/spark/dashboards/spark-metrics.json

--- a/TODO.org
+++ b/TODO.org
@@ -1,7 +1,11 @@
 #+TITLE: current
+* 931
+** Problem in JMX exporter doc: https://github.com/kubeflow/spark-operator/issues/2380
+** TODO https://github.com/LucaCanali/sparkMeasure
+https://github.com/chrissng/spark-on-k8s-monitoring-dashboard?tab=readme-ov-file
 * TODO enable fink-test to run test on fink releases (currently it runs only on branch master tips)
+* TODO monitor issue (prometheus doc): https://github.com/kubeflow/spark-operator/issues/2380
 * TODO hdfs operator management
-
 ** TODO limit and request for memory: monitor issue https://github.com/stackabletech/hdfs-operator/issues/625
 ** TODO open issue: zkfc on datanode is not compliant with memory setting
 In the example below memory limit is 256Mi for nameNode in hdfscluster CR, but it become 768Mi in each related pod because the `zkfs` container is not impacted by the CR configuration.
@@ -28,13 +32,12 @@ kubectl get pods -n hdfs simple-hdfs-namenode-default-0 -o jsonpath  -o=jsonpath
     "memory": "512Mi"
   }
 }
-
-
-** TODO management of argoCD default values (jqpath expression): monitor issue https://github.com/stackabletech/hdfs-operator/issues/626
+** TODO management of argoCD default values (jqpath expression): https://github.com/astrolabsoftware/fink-broker/issues/936
+monitor issue https://github.com/stackabletech/hdfs-operator/issues/626
 ** TODO open issue: be able to run only one dataNode on CI
 
 ** TODO Add helm option on HDFS cpu.min (also for operators!)
-** TODO Move fink image to docker.stackable.tech/stackable/hadoop:3.3.6-stackable24.11.
+** DONE Move fink image to docker.stackable.tech/stackable/hadoop:3.3.6-stackable24.11.
 
 #+TITLE: previous
 * TODO DELAYED BECAUSE IT NOT BLOCKS BUT WARN create topic in distribute before sending alerts in order to avoid error below: https://fink-broker.slack.com/archives/D03KJ390F17/p1692008729660549

--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    monitored: "true"

--- a/chart/templates/namespace.yaml
+++ b/chart/templates/namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Release.Namespace }}
+{{- if eq .Values.monitoring.enabled true }}
   labels:
     monitored: "true"
+{{- end }}

--- a/chart/templates/podmonitor.yaml
+++ b/chart/templates/podmonitor.yaml
@@ -1,0 +1,16 @@
+{{ if eq .Values.monitoring.enabled true -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: fink-broker
+  labels:
+    app.kubernetes.io/instance: fink-broker
+    monitored: "true"
+spec:
+  selector:
+    matchExpressions:
+      - key: "spark-role"
+        operator: "Exists"
+  podMetricsEndpoints:
+  - port: jmx-exporter
+{{- end }}

--- a/chart/templates/spark-fink-distribution.yaml
+++ b/chart/templates/spark-fink-distribution.yaml
@@ -43,3 +43,12 @@ spec:
     volumeMounts:
     - name: kafka-secret
       mountPath: /etc/fink-broker
+{{- if eq .Values.monitoring.enabled true }}
+  monitoring:
+    exposeDriverMetrics: true
+    exposeExecutorMetrics: true
+    prometheus:
+      # Added in Dockerfile
+      jmxExporterJar: "/opt/spark/jars/jmx_prometheus_javaagent-1.1.0.jar"
+      port: 8090
+{{- end }}

--- a/chart/templates/spark-fink-raw2science.yaml
+++ b/chart/templates/spark-fink-raw2science.yaml
@@ -27,3 +27,12 @@ spec:
     instances: {{ tpl .Values.raw2science.instances . }}
     labels:
       version: 3.4.1
+{{- if eq .Values.monitoring.enabled true }}
+  monitoring:
+    exposeDriverMetrics: true
+    exposeExecutorMetrics: true
+    prometheus:
+      # Added in Dockerfile
+      jmxExporterJar: "/opt/spark/jars/jmx_prometheus_javaagent-1.1.0.jar"
+      port: 8090
+{{- end }}

--- a/chart/templates/spark-fink-stream2raw.yaml
+++ b/chart/templates/spark-fink-stream2raw.yaml
@@ -37,4 +37,13 @@ spec:
     memory: "512m"
     labels:
       version: 3.4.1
+{{- if eq .Values.monitoring.enabled true }}
+  monitoring:
+    exposeDriverMetrics: true
+    exposeExecutorMetrics: true
+    prometheus:
+      # Added in Dockerfile
+      jmxExporterJar: "/opt/spark/jars/jmx_prometheus_javaagent-1.1.0.jar"
+      port: 8090
+{{- end }}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -26,6 +26,10 @@ producer: ztf
 
 log_level: INFO
 
+monitoring:
+  # Add JMX exporter to spark pods and create a PodMonitor
+  enabled: false
+
 #
 # Parameters used to run the stream2raw task
 #

--- a/doc/monitor.md
+++ b/doc/monitor.md
@@ -1,10 +1,13 @@
 # Monitor fink-broker platform
 
+## Quick start
+
 ```bash
 # Run the fink-ci script to install fink-broker from scratch
 fink-ci.sh -m -s -b <branch-name>
 
 # Port forward to grafana
+# login as admin with password prom-operator
 kubectl port-forward $(kubectl get  pods --selector=app.kubernetes.io/name=grafana -n  monitoring --output=jsonpath="{.items..metadata.name}") -n monitoring  3001:3000
 
 # Run ssh tunnel on workstation for remote access
@@ -13,4 +16,26 @@ ssh fink_lpc -L 3001:localhost:3001 -N
 # login: admin
 # password: prom-operator
 curl http://localhost:3001
+```
+
+## Troubleshoot
+
+```bash
+# Check exporter is enabled:
+kubectl exec -it -n spark fink-broker-stream2raw-driver -- curl http://localhost:8090/metrics
+
+# Watch JMX exporter configuration
+kubectl exec -it -n spark fink-broker-stream2raw-driver -- cat /etc/metrics/conf/prometheus.yaml
+
+# Check spark metrics availability in prometheus database:
+kubectl run -i --rm --tty shell --image=curlimages/curl -- sh
+METRIC_NAME="spark_driver_livelistenerbus_queue_streams_size_type_gauges"
+curl "http://prometheus-stack-kube-prom-prometheus.monitoring:9090/api/v1/query?query=$METRIC_NAME"
+
+# Prometheus access:
+kubectl port-forward -n monitoring prometheus-prometheus-stack-kube-prom-prometheus-0 9090
+
+# Grafana access:
+# login as admin with password prom-operator
+kubectl port-forward $(kubectl get  pods --selector=app.kubernetes.io/name=grafana -n  monitoring --output=jsonpath="{.items..metadata.name}") -n monitoring  3000 &
 ```

--- a/doc/troubleshoot.md
+++ b/doc/troubleshoot.md
@@ -28,6 +28,8 @@ argocd app sync fink-broker
 ```shell
 cd fink-broker
 helm install --debug fink ./chart -f ./chart/values-ci-noscience.yaml --dry-run
+# Or
+helm template --debug spark -f ./chart/values-ci-noscience.yaml --dry-run=client  -n spark ./chart
 ```
 
 ## ArgoCD

--- a/e2e/prereq-install.sh
+++ b/e2e/prereq-install.sh
@@ -9,15 +9,23 @@ set -euxo pipefail
 DIR=$(cd "$(dirname "$0")"; pwd -P)
 
 kind_version_opt=""
-cluster_name=$(ciux get clustername $DIR/..)
 monitoring=false
 
+usage () {
+    echo "Usage: $0 [-k kind_version] [-m]"
+    echo "  -k kind_version: kind version to install"
+    echo "  -m: install monitoring stack"
+    exit 1
+}
+
 # Get kind version from option -k
-while getopts mk: flag
+while getopts mk:h flag
 do
     case "${flag}" in
         k) kind_version_opt=--kind-version=${OPTARG};;
         m) monitoring=true;;
+        h) usage;;
+        *) usage; exit 1;;
     esac
 done
 
@@ -25,6 +33,7 @@ ktbx install kind $kind_version_opt
 ktbx install kubectl
 ktbx install helm
 ink "Create kind cluster"
+cluster_name=$(ciux get clustername $DIR/..)
 ktbx create -s --name $cluster_name
 ink "Install OLM"
 ktbx install olm

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -21,7 +21,7 @@ usage () {
 
 SUFFIX="noscience"
 
-ciux_version=v0.0.4-rc10
+ciux_version=v0.0.5-rc0
 export CIUXCONFIG=$HOME/.ciux/ciux.sh
 
 src_dir=$DIR/..
@@ -35,7 +35,7 @@ CIUX_IMAGE_URL="undefined"
 
 token="${TOKEN:-}"
 
-# Get options for suffix
+# Get options
 while getopts hcmsS: opt; do
   case ${opt} in
 
@@ -110,7 +110,7 @@ $src_dir/build.sh -s "$SUFFIX"
 build=true
 
 # e2e tests step
-ciux ignite --selector itest "$src_dir" --suffix "$SUFFIX"
+
 
 cluster=$(ciux get clustername "$src_dir")
 echo "Delete the cluster $cluster if it already exists"
@@ -124,14 +124,13 @@ then
 fi
 $DIR/prereq-install.sh $monitoring_opt
 
-
-. $CIUXCONFIG
+$(ciux get image --check $src_dir --suffix "$SUFFIX" --env)
 if [ $CIUX_BUILD = true ]; then
   kind load docker-image $CIUX_IMAGE_URL --name "$cluster"
 fi
 
 echo "Run ArgoCD to install the whole fink e2e tests stack"
-$DIR/argocd.sh -S "$storage"
+$DIR/argocd.sh -s "$SUFFIX" -S "$storage" $monitoring_opt
 
 echo "Check the results of the tests."
 $DIR/check-results.sh


### PR DESCRIPTION
- Add monitoring to all spark tasks
- Add prometheus JMX exporter jar in Dockerfile:
  * Use latest release jmx_prometheus_javaagent-1.1.0.jar
- Add support for monitoring in e2e test script
- Bump ciux to v0.0.5-rc0
- Add monitoring label to spark namespace
- Install and configure prometheus in CI
- Hack to try to solve kafka startup problem

**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #931 

## What changes were proposed in this pull request?

Prometheus integration

## How was this patch tested?

e2e test pass successfully