### PR TITLE
Add new crossmatch with Gaia variability table

### DIFF
--- a/fink_broker/common/science.py
+++ b/fink_broker/common/science.py
@@ -90,7 +90,13 @@ def apply_all_xmatch(df, tns_raw_output, survey=""):
         types=["string", "float", "float", "string"],
     )
 
-    df = df.withColumnRenamed("VarFlag", "gaiaVarFlag")
+    # VarFlag is a string. Make it integer
+    # 0=NOT_AVAILABLE
+    # 1=VARIABLE
+    df = df.withColumn(
+        "gaiaVarFlag", F.when(df["VarFlag"] == "VARIABLE", 1).otherwise(0)
+    )
+    df = df.drop("VarFlag")
 
     _LOG.info("New processor: Gaia var xmatch (1.0 arcsec)")
     df = xmatch_cds(

--- a/fink_broker/common/science.py
+++ b/fink_broker/common/science.py
@@ -81,14 +81,28 @@ def apply_all_xmatch(df, tns_raw_output, survey=""):
     _LOG.info("New processor: TNS")
     df = xmatch_tns(df, tns_raw_output=tns_raw_output)
 
-    _LOG.info("New processor: Gaia xmatch (1.0 arcsec)")
+    _LOG.info("New processor: Gaia main xmatch (1.0 arcsec)")
     df = xmatch_cds(
         df,
         distmaxarcsec=1,
         catalogname="vizier:I/355/gaiadr3",
-        cols_out=["DR3Name", "Plx", "e_Plx"],
-        types=["string", "float", "float"],
+        cols_out=["DR3Name", "Plx", "e_Plx", "VarFlag"],
+        types=["string", "float", "float", "string"],
     )
+
+    df = df.withColumnRenamed("VarFlag", "gaiaVarFlag")
+
+    _LOG.info("New processor: Gaia var xmatch (1.0 arcsec)")
+    df = xmatch_cds(
+        df,
+        distmaxarcsec=1,
+        catalogname="vizier:I/358/vclassre",
+        cols_out=["Class", "ClassSc"],
+        types=["string", "float"],
+    )
+
+    df = df.withColumnRenamed("Class", "gaiaClass")
+    df = df.withColumnRenamed("ClassSc", "gaiaClassSc")
 
     _LOG.info("New processor: VSX (1.5 arcsec)")
     df = xmatch_cds(

--- a/fink_broker/ztf/hbase_utils.py
+++ b/fink_broker/ztf/hbase_utils.py
@@ -45,7 +45,7 @@ def load_fink_cols():
     --------
     >>> fink_cols, fink_nested_cols = load_fink_cols()
     >>> print(len(fink_cols))
-    30
+    33
 
     >>> print(len(fink_nested_cols))
     7
@@ -81,6 +81,9 @@ def load_fink_cols():
         "spicy_id": {"type": "int", "default": -1},
         "spicy_class": {"type": "string", "default": "Unknown"},
         "tns": {"type": "string", "default": ""},
+        "gaiaVarFlag": {"type": "string", "default": "Unknown"},
+        "gaiaClass": {"type": "string", "default": "Unknown"},
+        "gaiaClassSc": {"type": "float", "default": 0.0},
     }
 
     fink_nested_cols = {}
@@ -108,7 +111,7 @@ def load_all_cols():
     >>> root_level, candidates, fink_cols, fink_nested_cols = load_all_cols()
     >>> out = {**root_level, **candidates, **fink_cols, **fink_nested_cols}
     >>> print(len(out))
-    145
+    148
     """
     fink_cols, fink_nested_cols = load_fink_cols()
 
@@ -319,7 +322,7 @@ def load_ztf_index_cols():
     --------
     >>> out = load_ztf_index_cols()
     >>> print(len(out))
-    73
+    76
     """
     # From `root` or `candidates.`
     common = [

--- a/fink_broker/ztf/hbase_utils.py
+++ b/fink_broker/ztf/hbase_utils.py
@@ -81,7 +81,7 @@ def load_fink_cols():
         "spicy_id": {"type": "int", "default": -1},
         "spicy_class": {"type": "string", "default": "Unknown"},
         "tns": {"type": "string", "default": ""},
-        "gaiaVarFlag": {"type": "string", "default": "Unknown"},
+        "gaiaVarFlag": {"type": "int", "default": 0},
         "gaiaClass": {"type": "string", "default": "Unknown"},
         "gaiaClassSc": {"type": "float", "default": 0.0},
     }


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #990 

## What changes were proposed in this pull request?

This PR adds a new crossmatch with Gaia DR3 Part 4. Variability (`I/358/vclassre`). Two new columns are added, `Class` and `ClassSc` which are renamed as `gaiaClass` and `gaiaClassSc` to avoid name clash.

We also add a new field, `VarFlag` from the main Gaia DR3 table, renamed as `gaiaVarFlag`, and we change the type from `string` to `integer`: `1 = VARIABLE, 0 otherwise`.

## How was this patch tested?

CI