### PR TITLE
[ZTF] Switch from float to double when storing slsn_score into HBase

### DIFF
--- a/fink_broker/ztf/hbase_utils.py
+++ b/fink_broker/ztf/hbase_utils.py
@@ -82,7 +82,7 @@ def load_fink_cols():
         "gaiaVarFlag": {"type": "int", "default": 0},
         "gaiaClass": {"type": "string", "default": "Unknown"},
         "is_transient": {"type": "boolean", "default": False},
-        "slsn_score": {"type": "float", "default": -1},
+        "slsn_score": {"type": "double", "default": -1},
     }
 
     fink_nested_cols = {}


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #1083 

## What changes were proposed in this pull request?

Change type for `slsn_score` when storing it into HBase.

## How was this patch tested?

CI