### PR TITLE
[k8s] Initialise dustmaps when creating the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,3 +100,6 @@ ADD deps/${input_survey}/requirements-science.txt $FINK_HOME/deps
 RUN pip install -r $FINK_HOME/deps/requirements.txt -r $FINK_HOME/deps/requirements-test.txt -r $FINK_HOME/deps/requirements-science.txt --use-pep517
 ADD deps/${input_survey}/requirements-science-no-deps.txt $FINK_HOME/deps
 RUN pip install -r $FINK_HOME/deps/requirements-science-no-deps.txt --no-deps
+
+# Finally initialise dustmaps
+RUN python -c "from dustmaps.config import config;import dustmaps.sfd;dustmaps.sfd.fetch()"


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #1089 

## What changes were proposed in this pull request?

Download maps used by dustmaps when creating the docker image for k8s pipelines.

## How was this patch tested?

CI