### PR TITLE
[Rubin] Add an option to reset offsets to the previous night

### DIFF
--- a/bin/fink
+++ b/bin/fink
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2025 AstroLab Software
+# Copyright 2019-2026 AstroLab Software
 # Author: Julien Peloton
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,6 +104,10 @@ while [ "$#" -gt 0 ]; do
       STOP_AT="$2"
       shift 2
       ;;
+    -reset_offsets_to)
+      RESET_OFFSETS_TO="$2"
+      shift 2
+      ;;
     --simulator)
       SIM_ONLY=true
       shift 1
@@ -159,6 +163,7 @@ Service options:
   -spark-executor-cores Number of cores per executor (see Spark options)
   -exit_after           Number of seconds after which the service should stop.
   -stop_at              Date at which the service should stop. Only available for rubin/stream2raw.
+  -reset_offsets_to Date to reprocess from (compatible only with rubin/stream2raw)
                         See -exit_after otherwise.
   --simulator           If specified, run in simulation mode.
   --noscience           If specified, do not enrich data with science modules.
@@ -316,6 +321,10 @@ if [[ ${SURVEY} == "rubin" ]] && [[ ${service} == "stream2raw" ]]; then
     CHECK_LSST_OFFSETS="--check_offsets"
   fi
 
+  if [[ "$RESET_OFFSETS_TO" ]] ; then
+    RESET_OFFSETS_TO="-reset_offsets_to ${RESET_OFFSETS_TO}"
+  fi
+
   python ${FINK_HOME}/bin/${SURVEY}/${service}.py \
     -lsst_kafka_server ${LSST_KAFKA_SERVER} \
     -lsst_schema_server ${LSST_SCHEMA_SERVER} \
@@ -334,7 +343,7 @@ if [[ ${SURVEY} == "rubin" ]] && [[ ${service} == "stream2raw" ]]; then
     -stop_polling_at "${STOP_AT}" \
     -night ${NIGHT} \
     -log ${LOG_LEVEL} \
-    -topic ${LSST_KAFKA_TOPIC} ${CHECK_LSST_OFFSETS}
+    -topic ${LSST_KAFKA_TOPIC} ${CHECK_LSST_OFFSETS} ${RESET_OFFSETS_TO}
 
 elif [[ $service == "fetch_schema" ]]; then
   if [[ -f $conf_stream2raw ]]; then


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #1025 

## What changes were proposed in this pull request?

This PR adds a new option to reset offsets to a given night in the past.

### Polling previous night data

It is easy to poll again data from the previous night:

```bash
# launched on 2026-01-07 mid-day
$ ./scheduler/rubin/launch_stream.sh --poll_only -reset_offsets_to "2026-01-07"

$ tail -f broker_logs/stream2raw_20260107.log
Comparing 2026-01-07 and now
Offsets per partitions: 
Now: 5284 - 2026-01-07: 5250
Now: 5439 - 2026-01-07: 5400
Now: 5080 - 2026-01-07: 5038
...
Now: 4603 - 2026-01-07: 4552
2155 missing alerts
✅ stream2raw exiting
```

It prints the last offset per partition, and the total number of alerts in between `now` and the target date (in this example the night `2026-01-07` has 2155 alerts). Note that this only reset offsets. Then poll again using standard command:

```bash
./scheduler/rubin/launch_stream.sh --poll_only
```

it should restart at the specified offsets.

### Polling several nights from the past

The option above works for any night in the past, but it will poll all nights in between the target night and `now`, and put inside the same directory (which is the current night)... This is not ideal, as one would have to split the data manually by date.

## How was this patch tested?

Cloud
