### PR TITLE
Standardize suffix management across build and e2e scripts

### DIFF
--- a/.github/workflows/e2e-common.yml
+++ b/.github/workflows/e2e-common.yml
@@ -167,10 +167,10 @@ jobs:
           # detached: true
       - name: Run argoCD
         run: |
-          ./e2e/argocd.sh -S "${{ matrix.storage }}" ${{ env.MONITORING_OPT}}
+          ./e2e/argocd.sh -s "${{ env.SUFFIX }}" -S "${{ matrix.storage }}" ${{ env.MONITORING_OPT}}
       - name: Check results
         run: |
-          ./e2e/check-results.sh
+          ./e2e/check-results.sh -s "${{ env.SUFFIX }}"
       - name: Delete cluster
         if: always()
         run: |

--- a/build.sh
+++ b/build.sh
@@ -33,14 +33,14 @@ Usage: `basename $0` [options]
 
   Available options:
     -h          this message
-    -s          image suffix, default to none, only 'noscience' is supported
+    -s          image suffix, default to 'noscience'. Valid values: 'noscience', 'science'
     -i 		Specify the survey. Default: ztf
 
 Build image containing fink-broker for k8s
 EOD
 }
 
-suffix=""
+suffix="noscience"
 tmp_registry=""
 input_survey="ztf"
 
@@ -56,6 +56,13 @@ while getopts hr:i:s: c ; do
 done
 shift `expr $OPTIND - 1`
 
+# Validate suffix value
+if [ -n "$suffix" ] && [ "$suffix" != "noscience" ] && [ "$suffix" != "science" ]; then
+    echo "Error: suffix must be 'noscience' or 'science'"
+    usage
+    exit 1
+fi
+
 ignite_msg="Run following command to prepare integration tests:"
 ignite_msg="${ignite_msg}  ciux ignite --selector ci \"$DIR\" --suffix \"$suffix\""
 
@@ -69,7 +76,7 @@ then
     exit 0
 fi
 
-if [[ $suffix =~ ^noscience* ]]; then
+if [[ "$suffix" == "noscience" ]]; then
     SELECTOR="build=noscience"
 else
     SELECTOR="build=science"
@@ -81,7 +88,7 @@ CIUXCONFIG=$(ciux get configpath --selector $SELECTOR $DIR)
 echo "Sourcing ciux config from $CIUXCONFIG"
 . $CIUXCONFIG
 
-if [[ $suffix =~ ^noscience* ]]; then
+if [[ "$suffix" == "noscience" ]]; then
     base_image="$ASTROLABSOFTWARE_FINK_FINK_DEPS_NOSCIENCE_ZTF_IMAGE"
 else
     base_image="$ASTROLABSOFTWARE_FINK_FINK_DEPS_SCIENCE_ZTF_IMAGE"

--- a/e2e/argocd.sh
+++ b/e2e/argocd.sh
@@ -22,7 +22,7 @@ usage() {
 Usage: $(basename "$0") [options]
 Available options:
   -h            This message
-  -s <suffix>   Suffix to use for the image (default: noscience)
+  -s <suffix>   Specify suffix ('noscience' or 'science'). Default: noscience
   -S <storage>  Storage to use (hdfs or minio)
 EOD
 }
@@ -38,6 +38,13 @@ while getopts hmS:s: c ; do
     esac
 done
 shift "$((OPTIND-1))"
+
+# Validate suffix value
+if [ -n "$SUFFIX" ] && [ "$SUFFIX" != "noscience" ] && [ "$SUFFIX" != "science" ]; then
+    echo "Error: suffix must be 'noscience' or 'science'"
+    usage
+    exit 1
+fi
 
 # Refresh ciux config if not in github actions
 # Used for interactive development

--- a/e2e/argocd.sh
+++ b/e2e/argocd.sh
@@ -28,6 +28,7 @@ EOD
 }
 
 # Get the options
+# -s has no effect in GIHUB_ACTION mode
 while getopts hmS:s: c ; do
     case $c in
         h) usage ; exit 0 ;;

--- a/e2e/check-results.sh
+++ b/e2e/check-results.sh
@@ -27,9 +27,9 @@ monitoring=false
 SUFFIX="noscience"
 
 usage () {
-  echo "Usage: $0 [-h] [-m]"
+  echo "Usage: $0 [-h] [-m] [-s <suffix>]"
   echo "  -m: Check monitoring is enabled"
-  echo "  -s: If not equal to 'noscience' use the science algorithms during the tests (default: noscience)"
+  echo "  -s: Specify suffix ('noscience' or 'science'). Default: noscience"
   echo "  -h: Display this help"
   echo ""
   echo " Check that the expected topics are created"
@@ -53,6 +53,13 @@ while getopts hms: opt; do
       ;;
   esac
 done
+
+# Validate suffix value
+if [ -n "$SUFFIX" ] && [ "$SUFFIX" != "noscience" ] && [ "$SUFFIX" != "science" ]; then
+    echo "Error: suffix must be 'noscience' or 'science'"
+    usage
+    exit 1
+fi
 
 # TODO improve management of expected topics
 # for example in finkctl.yaml

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -32,8 +32,8 @@ echo "Test report: $TEST_REPORT"
 echo "=================================="
 
 usage () {
-  echo "Usage: $0 [-c] [-h] [-m] [-s]"
-  echo "  -s: Use the science algorithms during the tests"
+  echo "Usage: $0 [-c] [-h] [-m] [-s <suffix>]"
+  echo "  -s: Specify suffix ('noscience' or 'science'). Default: noscience"
   echo "  -c: Cleanup the cluster after the tests"
   echo "  -i: Specify input survey. Default: ztf"
   echo "  -m: Install monitoring stack"
@@ -60,7 +60,7 @@ input_survey="ztf"
 token="${TOKEN:-}"
 
 # Get options for suffix
-while getopts hcmsi:S: opt; do
+while getopts hcms:i:S: opt; do
   case ${opt} in
 
     c )
@@ -74,7 +74,7 @@ while getopts hcmsi:S: opt; do
       monitoring=true
       ;;
     s )
-      SUFFIX=""
+      SUFFIX="$OPTARG"
       ;;
     i )
       input_survey="$OPTARG"
@@ -86,6 +86,13 @@ while getopts hcmsi:S: opt; do
       ;;
   esac
 done
+
+# Validate suffix value
+if [ -n "$SUFFIX" ] && [ "$SUFFIX" != "noscience" ] && [ "$SUFFIX" != "science" ]; then
+    echo "Error: suffix must be 'noscience' or 'science'"
+    usage
+    exit 1
+fi
 
 export SUFFIX
 


### PR DESCRIPTION
## Summary

This PR standardizes the suffix management across all build and e2e scripts to fix inconsistencies that were causing confusion and potential errors.

## Changes Made

### Scripts Modified:
- **`build.sh`**: Changed default from empty suffix to "noscience", added validation
- **`e2e/run.sh`**: Fixed `-s` option to accept value instead of being boolean, added validation  
- **`e2e/check-results.sh`**: Added strict validation for suffix values
- **`e2e/argocd.sh`**: Added strict validation (with note that `-s` has no effect in GitHub Actions mode)
- **`.github/workflows/e2e-common.yml`**: Pass suffix parameter explicitly to scripts

### Standardized Logic:
- **No `-s` option**: defaults to "noscience" (safe for testing)
- **`-s "noscience"`**: noscience mode
- **`-s "science"`**: science mode  
- **`-s ""`** or **invalid values**: error with clear message

### Validation Added:
All scripts now include strict validation:
```bash
if [ -n "$suffix" ] && [ "$suffix" != "noscience" ] && [ "$suffix" != "science" ]; then
    echo "Error: suffix must be 'noscience' or 'science'"
    usage
    exit 1
fi
```

## Testing

- GitHub Actions workflows will use the updated logic once merged to master
- Local development benefits from consistent behavior across all scripts

## Related Issue

Closes #1158

## Breaking Changes

- `e2e/run.sh`: `-s` option now requires a value (was previously boolean)
- All scripts now default to "noscience" instead of mixed defaults