### PR TITLE
[Rubin] Enable HBase skip for filters.

### DIFF
--- a/bin/rubin/distribute.py
+++ b/bin/rubin/distribute.py
@@ -28,6 +28,7 @@ import pkgutil
 import argparse
 import logging
 import time
+import importlib
 
 from fink_broker.common.distribution_utils import push_to_kafka, FakeQuery
 from fink_broker.common.logging_utils import init_logger
@@ -134,7 +135,10 @@ def main():
             logger.debug("Apply user-defined filter %s", userfilter)
             df_filtered = df.filter(fink_filter.for_spark(*colnames))
 
-        if not args.no_hbase_ingest:
+        # HBase support requires fink-filters>=7.34
+        module = userfilter.rsplit(".", maxsplit=1)[0]
+        hbase_support = importlib.import_module(module).HBASE_SUPPORT
+        if not args.no_hbase_ingest and hbase_support:
             # HBase ingestion
             major_version, minor_version = get_schema_from_parquet(scitmpdatapath)
 
@@ -155,7 +159,7 @@ def main():
                 checkpoint_path=checkpointpath_hbase + "/" + tag,
             )
         else:
-            logger.warning("Skipping HBase ingestion")
+            logger.warning("Skipping HBase ingestion for filter {}".format(userfilter))
             hbase_query = FakeQuery()
 
         if not args.no_kafka_ingest:
@@ -172,7 +176,7 @@ def main():
                 npart=10,
             )
         else:
-            logger.warning("Skipping Kafka ingestion")
+            logger.warning("Skipping Kafka ingestion for filter {}".format(userfilter))
             kafka_query = FakeQuery()
 
     if args.exit_after is not None:


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #1182

## What changes were proposed in this pull request?

Skip live HBase push for Rubin filters without HBase support. This requires fink-filters>=7.34.

## How was this patch tested?

CI
