### PR TITLE
Bump fink-deps images to v2.54.4

### DIFF
--- a/.ciux
+++ b/.ciux
@@ -34,10 +34,10 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/stackable-hadoop:v24.11.0
     labels:
       itest: "true"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.3
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.4
     labels:
       build: "noscience"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.3
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.4
     labels:
       build: "science"
   - package: github.com/k8s-school/ktbx@v1.1.6-rc5

--- a/.ciux
+++ b/.ciux
@@ -34,10 +34,10 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/stackable-hadoop:v24.11.0
     labels:
       itest: "true"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.0-8-g0edb443
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.3
     labels:
       build: "noscience"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.0-8-g0edb443
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.3
     labels:
       build: "science"
   - package: github.com/k8s-school/ktbx@v1.1.6-rc5

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      # Use an explicitly pinned image tag to keep workflow runs reproducible
-      # and make dependency updates deliberate.
-      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.0-8-g0edb443
+      # Warning: use of 'latest' tag is discouraged in production because it can lead to non-reproducible runs,
+      # it is used here for simplicity
+      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.3
 
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       # Warning: use of 'latest' tag is discouraged in production because it can lead to non-reproducible runs,
       # it is used here for simplicity
-      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.3
+      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.4
 
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      # Warning: use of 'latest' tag is discouraged in production because it can lead to non-reproducible runs,
-      # it is used here for simplicity
+      # Container image is pinned to a specific tag for reproducible runs.
+      # Bump this tag explicitly when updating Sentinel dependencies.
       image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.4
 
     env:

--- a/e2e/check-results.sh
+++ b/e2e/check-results.sh
@@ -74,7 +74,7 @@ fi
 # Wait for topics to be created, and check if fink-broker has not crashed in the meantime
 # display logs of failed pods if any, and of running pods if no topics after 10 attempts (~10 minutes)
 count=0
-max_attempts=10
+max_attempts=20
 selector="spark-app-name"
 err_msg=""
 while ! finkctl wait topics --expected "$expected_topics" --timeout 60s -v1 > /dev/null
@@ -114,7 +114,7 @@ do
           echo "--- Logs for Pod: $pod ---"
           kubectl logs "$pod" -n spark --tail -1
       done
-      err_msg="ERROR: fink-broker did not produce expected results after ~10 minutes"
+      err_msg="ERROR: fink-broker did not produce expected results after ~20 minutes"
       # echo "ERROR: enabling interactive access for debugging purpose" 1>&2
       # sleep 7200
       break


### PR DESCRIPTION
## Summary
- Bump `fink-deps-noscience-ztf` and `fink-deps-science-ztf` from `v2.54.0` to `v2.54.3` in `.ciux`
- Bump `fink-deps-sentinel` from `v2.52.0-85-g9ada7fd` to `v2.54.3` in sentinel workflow