### PR TITLE
[ZTF] enable full recomputation of ephemerides

### DIFF
--- a/bin/ztf/compute_ephemerides.py
+++ b/bin/ztf/compute_ephemerides.py
@@ -88,6 +88,7 @@ def aggregate_and_add_ephem(year, month, npart, prefix_path, limit, logger):
             F.lit(15.0),
             F.expr("uuid()"),
             F.lit("ephemcc"),
+            F.lit("ephemcc-photom.xml"),
         ),
     )
     df_expanded = expand_columns(df_new, col_to_expand=col_)

--- a/bin/ztf/compute_ephemerides.py
+++ b/bin/ztf/compute_ephemerides.py
@@ -153,7 +153,7 @@ def make_checks(prefix_path, year=None, monthly=None, logger=None):
         is_data = path_exist(path)
 
     if is_ephem:
-        logger.warnCing("{} found on HDFS. Skipping the computation".format(filename))
+        logger.warning("{} found on HDFS. Skipping the computation".format(filename))
 
     if not is_data:
         logger.warning("No data found for {}. Skipping...".format(path))
@@ -209,44 +209,13 @@ def main():
 
     if args.mode == "all":
         years = range(2019, datetime.datetime.now().year + 1)
-        is_starting = True
-        for year in years:
-            logger.info("Processing data from {}".format(year))
+        logger.info("Processing data from {} to {}".format(years[0], years[-1]))
 
-            # Skip computation if necessary
-            is_ephem, is_data = make_checks(args.prefix_path, year=year, logger=logger)
-            if is_ephem:
-                is_starting = False
-                continue
-            if not is_data:
-                continue
+        df_new = aggregate_and_add_ephem(
+            None, None, nparts, args.prefix_path, args.limit, logger
+        )
 
-            if is_starting:
-                logger.info("Initialising data from {}".format(year))
-                # initialisation
-                df = aggregate_and_add_ephem(
-                    year, None, nparts, args.prefix_path, args.limit, logger
-                )
-
-                df.write.mode("overwrite").parquet(SSO_FILE.format(year, ""))
-                is_starting = False
-                continue
-
-            df_new = aggregate_and_add_ephem(
-                year, None, nparts, args.prefix_path, args.limit, logger
-            )
-
-            logger.info("Loading previous data...")
-            df_prev = spark.read.format("parquet").load(SSO_FILE.format(year - 1, ""))
-
-            logger.info("Joining previous and new data...")
-            assert sorted(df_prev.columns) == sorted(df_new.columns), (
-                df_prev.columns,
-                df_new.columns,
-            )
-            df_join = join_aggregated_sso_data(df_prev, df_new, on="ssnamenr")
-
-            df_join.write.mode("overwrite").parquet(SSO_FILE.format(year, ""))
+        df_new.write.mode("overwrite").parquet(SSO_FILE.format(years[-1], ""))
     elif args.mode == "last_month":
         # get last month coordinates
         lm = retrieve_last_date_of_previous_month(datetime.datetime.now())

--- a/bin/ztf/compute_ephemerides.py
+++ b/bin/ztf/compute_ephemerides.py
@@ -54,7 +54,10 @@ def aggregate_and_add_ephem(year, month, npart, prefix_path, limit, logger):
     -------
     out: Spark DataFrame
     """
-    if month is None:
+    if (year is None) and (month is None):
+        logger.info("Aggregating ALL data")
+        df_new = aggregate_ztf_sso_data(prefix_path=prefix_path)
+    elif (year is not None) and (month is None):
         logger.info("Aggregating data from {}".format(year))
         current_year = datetime.datetime.now().year
         df_new = aggregate_ztf_sso_data(
@@ -62,7 +65,7 @@ def aggregate_and_add_ephem(year, month, npart, prefix_path, limit, logger):
             stop_previous_month=(year == current_year),
             prefix_path=prefix_path,
         )
-    else:
+    elif (year is not None) and (month is not None):
         logger.info("Aggregating data from {}{}".format(year, month))
         df_new = aggregate_ztf_sso_data(year=year, month=month, prefix_path=prefix_path)
 
@@ -74,10 +77,6 @@ def aggregate_and_add_ephem(year, month, npart, prefix_path, limit, logger):
     df_new = df_new.repartition(npart).cache()
     logger.info("{} objects".format(df_new.count()))
 
-    if month is None:
-        logger.info("Aggregating ephemerides from {}".format(year))
-    else:
-        logger.info("Aggregating ephemerides from {}{}".format(year, month))
     col_ = "ephem"
     df_new = df_new.withColumn(
         col_,

--- a/bin/ztf/push_to_tns.py
+++ b/bin/ztf/push_to_tns.py
@@ -121,7 +121,9 @@ def main():
         print(r.json())
 
         # post to slack
-        slacktxt = " \n ".join(["https://ztf.fink-portal.org/{}".format(i) for i in ids])
+        slacktxt = " \n ".join([
+            "https://ztf.fink-portal.org/{}".format(i) for i in ids
+        ])
         slacktxt = "{} \n ".format(args.night) + slacktxt
         r = requests.post(
             os.environ["TNSWEBHOOK"],


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes #1191

## What changes were proposed in this pull request?

This PR modifies the ephemerides script to re-run all ephemerides in one-go instead of looping over years.
This greatly speeds-up the process, as for each ephemeride call, the runtime is moderately correlated with the number of observations but we have overheads due to initialisation for ephemerides computation (for most objects, we go from N calls - one per year - to 1 call).


## How was this patch tested?

Cloud
