### PR TITLE
Remove deprecated PandasUDFType from pandas UDF decorators

### DIFF
--- a/.ciux
+++ b/.ciux
@@ -34,10 +34,10 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/stackable-hadoop:v24.11.0
     labels:
       itest: "true"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.4
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.5-rc0
     labels:
       build: "noscience"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.4
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.5-rc0
     labels:
       build: "science"
   - package: github.com/k8s-school/ktbx@v1.1.6-rc5

--- a/.ciux
+++ b/.ciux
@@ -34,10 +34,10 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/stackable-hadoop:v24.11.0
     labels:
       itest: "true"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc4
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc5
     labels:
       build: "noscience"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc4
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc5
     labels:
       build: "science"
   - package: github.com/k8s-school/ktbx@v1.1.6-rc5

--- a/.ciux
+++ b/.ciux
@@ -34,10 +34,10 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/stackable-hadoop:v24.11.0
     labels:
       itest: "true"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.5-rc0
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc0
     labels:
       build: "noscience"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.5-rc0
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc0
     labels:
       build: "science"
   - package: github.com/k8s-school/ktbx@v1.1.6-rc5

--- a/.ciux
+++ b/.ciux
@@ -34,10 +34,10 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/stackable-hadoop:v24.11.0
     labels:
       itest: "true"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc3
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc4
     labels:
       build: "noscience"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc3
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc4
     labels:
       build: "science"
   - package: github.com/k8s-school/ktbx@v1.1.6-rc5

--- a/.ciux
+++ b/.ciux
@@ -34,10 +34,10 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/stackable-hadoop:v24.11.0
     labels:
       itest: "true"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc0
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc1
     labels:
       build: "noscience"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc0
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc1
     labels:
       build: "science"
   - package: github.com/k8s-school/ktbx@v1.1.6-rc5

--- a/.ciux
+++ b/.ciux
@@ -34,10 +34,10 @@ dependencies:
   - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/stackable-hadoop:v24.11.0
     labels:
       itest: "true"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc1
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-noscience-ztf:v2.54.7-rc3
     labels:
       build: "noscience"
-  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc1
+  - image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-science-ztf:v2.54.7-rc3
     labels:
       build: "science"
   - package: github.com/k8s-school/ktbx@v1.1.6-rc5

--- a/.github/workflows/e2e-common.yml
+++ b/.github/workflows/e2e-common.yml
@@ -145,11 +145,24 @@ jobs:
           node=$(kubectl get nodes --selector=node-role.kubernetes.io/control-plane -o jsonpath='{.items[0].metadata.name}')
           docker exec -- $node crictl image
       - name: Run argoCD
+        id: run_argocd
         run: |
           ./e2e/argocd.sh -s "${{ env.SUFFIX }}" -S "${{ matrix.storage }}" ${{ env.MONITORING_OPT}}
       - name: Check results
+        id: check_results
         run: |
           ./e2e/check-results.sh -s "${{ env.SUFFIX }}"
+      - name: Collect diagnostics
+        if: always() && (steps.run_argocd.outcome == 'failure' || steps.check_results.outcome == 'failure')
+        run: |
+          ./e2e/diag.sh /tmp/k8s-diag
+      - name: Upload diagnostics artifacts
+        if: always() && (steps.run_argocd.outcome == 'failure' || steps.check_results.outcome == 'failure')
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-diag-${{ matrix.storage }}
+          path: /tmp/k8s-diag
+          retention-days: 7
       - name: Delete cluster
         if: always()
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff
+        pip install ruff==0.15.16
     - name: fink-broker
       run: |
         ruff check --statistics fink_broker/*/*.py

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff==0.15.16
+        pip install ruff
     - name: fink-broker
       run: |
         ruff check --statistics fink_broker/*/*.py

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       # Container image is pinned to a specific tag for reproducible runs.
       # Bump this tag explicitly when updating Sentinel dependencies.
-      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.4
+      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.5-rc0
 
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       # Container image is pinned to a specific tag for reproducible runs.
       # Bump this tag explicitly when updating Sentinel dependencies.
-      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc3
+      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc4
 
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       # Container image is pinned to a specific tag for reproducible runs.
       # Bump this tag explicitly when updating Sentinel dependencies.
-      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc0
+      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc1
 
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -12,7 +12,7 @@ on:
         description: 'Survey name (ztf or rubin)'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.survey }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       # Container image is pinned to a specific tag for reproducible runs.
       # Bump this tag explicitly when updating Sentinel dependencies.
-      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc4
+      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc5
 
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       # Container image is pinned to a specific tag for reproducible runs.
       # Bump this tag explicitly when updating Sentinel dependencies.
-      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc1
+      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc3
 
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sentinel-template.yml
+++ b/.github/workflows/sentinel-template.yml
@@ -22,7 +22,7 @@ jobs:
     container:
       # Container image is pinned to a specific tag for reproducible runs.
       # Bump this tag explicitly when updating Sentinel dependencies.
-      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.5-rc0
+      image: gitlab-registry.in2p3.fr/astrolabsoftware/fink/fink-deps-sentinel-${{ inputs.survey }}:v2.54.7-rc0
 
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -42,8 +42,9 @@ ignore = [
     "C408", "C420", "C901",
     "D400", "D401", "D100", "D102", "D103", "D104", "D415", "D419", 
     "E731",
-    "N812", "N806", "N803", 
+    "N812", "N806", "N803",
     "PLR0913",
+    "D420",
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -44,7 +44,6 @@ ignore = [
     "E731",
     "N812", "N806", "N803", 
     "PLR0913",
-    "D420"
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/bin/elasticc/distribute_elasticc.py
+++ b/bin/elasticc/distribute_elasticc.py
@@ -66,7 +66,7 @@ def format_df_to_elasticc(df):
     # Add non existing columns
     df = df.withColumn(
         "elasticcPublishTimestamp",
-        convert_to_millitime(df["diaSource.midPointTai"], F.lit("mjd")),
+        convert_to_millitime(df["diaSource.midPointTai"], "mjd"),
     )
     df = df.withColumn("brokerName", F.lit("Fink"))
     df = df.withColumn("brokerVersion", F.lit("{}".format(fbvsn)))

--- a/bin/rubin/merge.py
+++ b/bin/rubin/merge.py
@@ -62,7 +62,7 @@ def main():
 
     df_science.withColumn(
         "timestamp",
-        convert_to_datetime(df_science["diaSource.midpointMjdTai"], F.lit("mjd")),
+        convert_to_datetime(df_science["diaSource.midpointMjdTai"], "mjd"),
     ).withColumn("year", F.lit(args.night[0:4])).withColumn(
         "month", F.lit(args.night[4:6])
     ).withColumn("day", F.lit(args.night[6:8])).coalesce(npart_after).write.mode(

--- a/bin/rubin/raw2science.py
+++ b/bin/rubin/raw2science.py
@@ -71,7 +71,7 @@ def main():
     # Add ingestion timestamp
     df = df.withColumn(
         "brokerStartProcessTimestamp",
-        convert_to_millitime(df["diaSource.midpointMjdTai"], F.lit("mjd"), F.lit(True)),
+        convert_to_millitime(df["diaSource.midpointMjdTai"], "mjd", True),
     )
 
     # Add library versions
@@ -100,7 +100,7 @@ def main():
     logger.debug("Add ingestion timestamp")
     df = df.withColumn(
         "brokerEndProcessTimestamp",
-        convert_to_millitime(df["diaSource.midpointMjdTai"], F.lit("mjd"), F.lit(True)),
+        convert_to_millitime(df["diaSource.midpointMjdTai"], "mjd", True),
     )
 
     logger.debug("Append new rows in the tmp science data lake")

--- a/bin/ztf/merge.py
+++ b/bin/ztf/merge.py
@@ -60,7 +60,7 @@ def main():
     # run test data with any candidate.jd under the same
     # fake night.
     df_raw.withColumn(
-        "timestamp", convert_to_datetime(df_raw["candidate.jd"])
+        "timestamp", convert_to_datetime(df_raw["candidate.jd"], F.lit("jd"))
     ).withColumn("year", F.lit(args.night[0:4])).withColumn(
         "month", F.lit(args.night[4:6])
     ).withColumn("day", F.lit(args.night[6:8])).coalesce(
@@ -83,7 +83,7 @@ def main():
     )
 
     df_science.withColumn(
-        "timestamp", convert_to_datetime(df_science["candidate.jd"])
+        "timestamp", convert_to_datetime(df_science["candidate.jd"], F.lit("jd"))
     ).withColumn("year", F.lit(args.night[0:4])).withColumn(
         "month", F.lit(args.night[4:6])
     ).withColumn("day", F.lit(args.night[6:8])).coalesce(npart_after).write.mode(

--- a/bin/ztf/merge.py
+++ b/bin/ztf/merge.py
@@ -60,7 +60,7 @@ def main():
     # run test data with any candidate.jd under the same
     # fake night.
     df_raw.withColumn(
-        "timestamp", convert_to_datetime(df_raw["candidate.jd"], F.lit("jd"))
+        "timestamp", convert_to_datetime(df_raw["candidate.jd"], "jd")
     ).withColumn("year", F.lit(args.night[0:4])).withColumn(
         "month", F.lit(args.night[4:6])
     ).withColumn("day", F.lit(args.night[6:8])).coalesce(
@@ -83,7 +83,7 @@ def main():
     )
 
     df_science.withColumn(
-        "timestamp", convert_to_datetime(df_science["candidate.jd"], F.lit("jd"))
+        "timestamp", convert_to_datetime(df_science["candidate.jd"], "jd")
     ).withColumn("year", F.lit(args.night[0:4])).withColumn(
         "month", F.lit(args.night[4:6])
     ).withColumn("day", F.lit(args.night[6:8])).coalesce(npart_after).write.mode(

--- a/bin/ztf/raw2science.py
+++ b/bin/ztf/raw2science.py
@@ -70,7 +70,7 @@ def main():
     # Add ingestion timestamp
     df = df.withColumn(
         "brokerStartProcessTimestamp",
-        convert_to_millitime(df["candidate.jd"], F.lit("jd"), F.lit(True)),
+        convert_to_millitime(df["candidate.jd"], "jd", True),
     )
 
     # Add library versions
@@ -106,7 +106,7 @@ def main():
     logger.debug("Add ingestion timestamp")
     df = df.withColumn(
         "brokerEndProcessTimestamp",
-        convert_to_millitime(df["candidate.jd"], F.lit("jd"), F.lit(True)),
+        convert_to_millitime(df["candidate.jd"], "jd", True),
     )
 
     logger.debug("Append new rows in the tmp science database")

--- a/bin/ztf/stream2raw.py
+++ b/bin/ztf/stream2raw.py
@@ -130,7 +130,7 @@ def main():
         # Add ingestion timestamp
         df_decoded = df_decoded.withColumn(
             "brokerIngestTimestamp",
-            convert_to_millitime(df_decoded["candidate.jd"], F.lit("jd"), F.lit(True)),
+            convert_to_millitime(df_decoded["candidate.jd"], "jd", True),
         )
 
         # write unpartitioned data
@@ -143,12 +143,12 @@ def main():
 
     elif "diaSource" in df_decoded.columns:
         timecol = "diaSource.midPointTai"
-        converter = lambda x: convert_to_datetime(x, F.lit("mjd"))
+        converter = lambda x: convert_to_datetime(x, "mjd")
 
         # Add ingestion timestamp
         df_decoded = df_decoded.withColumn(
             "brokerIngestTimestamp",
-            convert_to_millitime(df_decoded[timecol], F.lit("mjd"), F.lit(True)),
+            convert_to_millitime(df_decoded[timecol], "mjd", True),
         )
 
         df_partitionedby = (

--- a/e2e/diag.sh
+++ b/e2e/diag.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Collect Kubernetes diagnostics for CI failure analysis
+
+# @author  Fabrice Jammes
+
+set -uo pipefail
+
+DIAG_DIR="${1:-/tmp/k8s-diag}"
+mkdir -p "$DIAG_DIR"
+
+echo "=== kubectl get pods -A ==="
+kubectl get pods -A --no-headers | tee "$DIAG_DIR/pods-all.txt"
+
+# Pods not in a healthy terminal or running state
+abnormal_pods=$(kubectl get pods -A --no-headers | \
+    grep -v -E '\s+(Running|Completed|Succeeded|Terminating)\s+' | \
+    awk '{print $1"/"$2}') || true
+
+if [ -z "$abnormal_pods" ]; then
+    echo "No abnormal pods found"
+    exit 0
+fi
+
+echo "=== Abnormal pods ==="
+echo "$abnormal_pods"
+
+for ns_pod in $abnormal_pods; do
+    ns=$(echo "$ns_pod" | cut -d'/' -f1)
+    pod=$(echo "$ns_pod" | cut -d'/' -f2)
+    safe_name="${ns}-${pod}"
+
+    echo "--- kubectl describe pod $pod -n $ns ---"
+    kubectl describe pod "$pod" -n "$ns" > "$DIAG_DIR/describe-${safe_name}.txt" 2>&1 || true
+
+    echo "--- kubectl logs $pod -n $ns ---"
+    kubectl logs "$pod" -n "$ns" --all-containers=true \
+        > "$DIAG_DIR/logs-${safe_name}.txt" 2>&1 || true
+
+    kubectl logs "$pod" -n "$ns" --all-containers=true --previous \
+        > "$DIAG_DIR/logs-prev-${safe_name}.txt" 2>&1 || true
+done

--- a/e2e/diag.sh
+++ b/e2e/diag.sh
@@ -29,7 +29,7 @@ kubectl get pods -A --no-headers | tee "$DIAG_DIR/pods-all.txt"
 
 # Pods not in a healthy terminal or running state
 abnormal_pods=$(kubectl get pods -A --no-headers | \
-    grep -v -E '\s+(Running|Completed|Succeeded|Terminating)\s+' | \
+    grep -v -E '[[:space:]]+(Running|Completed|Succeeded|Terminating)[[:space:]]+' | \
     awk '{print $1"/"$2}') || true
 
 if [ -z "$abnormal_pods" ]; then

--- a/fink_broker/common/partitioning.py
+++ b/fink_broker/common/partitioning.py
@@ -38,7 +38,7 @@ def convert_to_millitime(jd: Column, format: str = "jd", now: bool = False) -> C
     Returns
     -------
     out: Column
-        UTC timestamps (TimestampType)
+        Spark Column of UTC timestamps (TimestampType)
 
     Examples
     --------

--- a/fink_broker/common/partitioning.py
+++ b/fink_broker/common/partitioning.py
@@ -50,6 +50,7 @@ def convert_to_millitime(jd: Column, format: str = "jd", now: bool = False) -> C
     >>> df = df.withColumn('millis', convert_to_millitime(df['candidate.jd'], 'jd', True))
     >>> pdf = df.select('millis').toPandas()
     """
+
     @pandas_udf(TimestampType())
     def _impl(jd: pd.Series) -> pd.Series:
         if now:
@@ -57,6 +58,7 @@ def convert_to_millitime(jd: Column, format: str = "jd", now: bool = False) -> C
         else:
             times = Time(jd.to_numpy(), format=format).to_datetime()
         return pd.Series(times)
+
     return _impl(jd)
 
 
@@ -95,9 +97,11 @@ def convert_to_datetime(jd: Column, format: str = "jd") -> Column:
     >>> df = df.withColumn('datetime', convert_to_datetime(df['candidate.jd']))
     >>> pdf = df.select('datetime').toPandas()
     """
+
     @pandas_udf(TimestampType())
     def _impl(jd: pd.Series) -> pd.Series:
         return pd.Series(Time(jd.to_numpy(), format=format).to_datetime())
+
     return _impl(jd)
 
 

--- a/fink_broker/common/partitioning.py
+++ b/fink_broker/common/partitioning.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import TimestampType
-from pyspark.sql import SparkSession
+from pyspark.sql import SparkSession, Column
 
 import numpy as np
 import pandas as pd
@@ -23,22 +23,21 @@ from astropy.time import Time
 from fink_broker.common.tester import spark_unit_tests
 
 
-@pandas_udf(TimestampType())
-def convert_to_millitime(jd: pd.Series, format=None, now=None):
+def convert_to_millitime(jd: Column, format: str = "jd", now: bool = False) -> Column:
     """Convert date into unix milliseconds (long)
 
     Parameters
     ----------
-    jd: double
-        Julian date
+    jd: Column
+        Julian date column
     format: str, optional
         Astropy time format, e.g. jd, mjd, ... Default is jd.
-    now: boolean, optional
-        If True, return the current time. Default is False
+    now: bool, optional
+        If True, return the current time. Default is False.
 
     Returns
     -------
-    out: pd.Series
+    out: Column
         Unix milliseconds in UTC
 
     Examples
@@ -48,26 +47,20 @@ def convert_to_millitime(jd: pd.Series, format=None, now=None):
     >>> df = df.withColumn('millis', convert_to_millitime(df['candidate.jd']))
     >>> pdf = df.select('millis').toPandas()
 
-    >>> import pyspark.sql.functions as F
-    >>> df = df.withColumn('millis', convert_to_millitime(
-    ...     df['candidate.jd'], F.lit('jd'), F.lit(True)))
+    >>> df = df.withColumn('millis', convert_to_millitime(df['candidate.jd'], 'jd', True))
     >>> pdf = df.select('millis').toPandas()
     """
-    if format is None:
-        formatval = "jd"
-    else:
-        formatval = format.to_numpy()[0]
-
-    if now is not None:
-        times = [Time.now().to_datetime()] * len(jd)
-    else:
-        times = Time(jd.to_numpy(), format=formatval).to_datetime()
-
-    return pd.Series(times)
+    @pandas_udf(TimestampType())
+    def _impl(jd: pd.Series) -> pd.Series:
+        if now:
+            times = [Time.now().to_datetime()] * len(jd)
+        else:
+            times = Time(jd.to_numpy(), format=format).to_datetime()
+        return pd.Series(times)
+    return _impl(jd)
 
 
-@pandas_udf(TimestampType())
-def convert_to_datetime(jd: pd.Series, format=None) -> pd.Series:
+def convert_to_datetime(jd: Column, format: str = "jd") -> Column:
     """Convert date into datetime (timestamp)
 
     Be careful if you are using this outside Fink. First, you need to check
@@ -83,18 +76,17 @@ def convert_to_datetime(jd: pd.Series, format=None) -> pd.Series:
     spark.conf.set("spark.sql.session.timeZone", 'UTC')
     ```
 
-
     Parameters
     ----------
-    jd: double
-        Julian date
-    format: str
-        Astropy time format, e.g. jd, mjd, ...
+    jd: Column
+        Julian date column
+    format: str, optional
+        Astropy time format, e.g. jd, mjd, ... Default is jd.
 
     Returns
     -------
-    out: datetime
-        Datetime object in UTC
+    out: Column
+        Datetime column in UTC
 
     Examples
     --------
@@ -103,12 +95,10 @@ def convert_to_datetime(jd: pd.Series, format=None) -> pd.Series:
     >>> df = df.withColumn('datetime', convert_to_datetime(df['candidate.jd']))
     >>> pdf = df.select('datetime').toPandas()
     """
-    if format is None:
-        formatval = "jd"
-    else:
-        formatval = format.to_numpy()[0]
-
-    return pd.Series(Time(jd.to_numpy(), format=formatval).to_datetime())
+    @pandas_udf(TimestampType())
+    def _impl(jd: pd.Series) -> pd.Series:
+        return pd.Series(Time(jd.to_numpy(), format=format).to_datetime())
+    return _impl(jd)
 
 
 def compute_num_part(df, partition_size=128.0):

--- a/fink_broker/common/partitioning.py
+++ b/fink_broker/common/partitioning.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import TimestampType
 from pyspark.sql import SparkSession
 
@@ -23,7 +23,7 @@ from astropy.time import Time
 from fink_broker.common.tester import spark_unit_tests
 
 
-@pandas_udf(TimestampType(), PandasUDFType.SCALAR)
+@pandas_udf(TimestampType())
 def convert_to_millitime(jd: pd.Series, format=None, now=None):
     """Convert date into unix milliseconds (long)
 
@@ -66,7 +66,7 @@ def convert_to_millitime(jd: pd.Series, format=None, now=None):
     return pd.Series(times)
 
 
-@pandas_udf(TimestampType(), PandasUDFType.SCALAR)
+@pandas_udf(TimestampType())
 def convert_to_datetime(jd: pd.Series, format=None) -> pd.Series:
     """Convert date into datetime (timestamp)
 

--- a/fink_broker/common/partitioning.py
+++ b/fink_broker/common/partitioning.py
@@ -38,7 +38,7 @@ def convert_to_millitime(jd: Column, format: str = "jd", now: bool = False) -> C
     Returns
     -------
     out: Column
-        Unix milliseconds in UTC
+        UTC timestamps (TimestampType)
 
     Examples
     --------

--- a/fink_broker/common/spark_utils.py
+++ b/fink_broker/common/spark_utils.py
@@ -21,7 +21,7 @@ from pyspark.sql import DataFrame
 from pyspark.sql.column import Column, _to_java_column
 from pyspark.sql.types import StructType
 
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 from pyspark.sql.types import StringType, LongType
 
 
@@ -526,7 +526,7 @@ def ra2phi(ra: float) -> float:
     return np.pi / 180.0 * ra
 
 
-@pandas_udf(LongType(), PandasUDFType.SCALAR)
+@pandas_udf(LongType())
 def ang2pix(ra: pd.Series, dec: pd.Series, nside: pd.Series) -> pd.Series:
     """Compute pixel number at given nside
 
@@ -564,7 +564,7 @@ def ang2pix(ra: pd.Series, dec: pd.Series, nside: pd.Series) -> pd.Series:
     )
 
 
-@pandas_udf(StringType(), PandasUDFType.SCALAR)
+@pandas_udf(StringType())
 def ang2pix_array(ra: pd.Series, dec: pd.Series, nside: pd.Series) -> pd.Series:
     """Return a col string with the pixel numbers corresponding to the nsides
 

--- a/fink_broker/ztf/tracklet_identification.py
+++ b/fink_broker/ztf/tracklet_identification.py
@@ -17,7 +17,7 @@
 
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
-from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.functions import pandas_udf
 
 import os
 import numpy as np
@@ -121,7 +121,6 @@ def add_tracklet_information(df: DataFrame) -> DataFrame:
         ]
     )
 
-    @pandas_udf(df_filt_tracklet.schema, PandasUDFType.GROUPED_MAP)
     def extract_tracklet_number(pdf: pd.DataFrame) -> pd.DataFrame:
         """Extract tracklet ID from a Spark DataFrame
 
@@ -330,7 +329,7 @@ def add_tracklet_information(df: DataFrame) -> DataFrame:
         df_filt_tracklet.cache()
         .dropDuplicates(["jd", "xpos", "ypos"])
         .groupBy("jd")
-        .apply(extract_tracklet_number)
+        .applyInPandas(extract_tracklet_number, schema=df_filt_tracklet.schema)
         .select(["candid", "tracklet"])
         .filter(F.col("tracklet") != "")
     )

--- a/fink_broker/ztf/tracklet_identification.py
+++ b/fink_broker/ztf/tracklet_identification.py
@@ -17,7 +17,6 @@
 
 from pyspark.sql import DataFrame
 import pyspark.sql.functions as F
-from pyspark.sql.functions import pandas_udf
 
 import os
 import numpy as np


### PR DESCRIPTION
## Summary
- Remove deprecated `PandasUDFType` usage from pandas UDF decorators (SPARK-28264), migrating GROUPED_MAP UDFs to `applyInPandas()`
- Refactor `convert_to_millitime`/`convert_to_datetime` to use a closure pattern, since PySpark doesn't support `Optional[pd.Series]` type hints in pandas UDF decorators; update callers to pass plain strings/bools instead of `F.lit()` columns
- Add Kubernetes diagnostics collection on CI failure (pod statuses, describe, logs) uploaded as artifacts
- Bump fink-deps images to v2.54.7-rc5 (includes the fink-science fix)
- Misc CI fixes: ruff lint, relax GHA concurrency constraints

Closes #1200

## Related PRs
- astrolabsoftware/fink-science#705
- astrolabsoftware/fink-broker-images#37