### PR TITLE
Remove --preview flag and E2 rule from ruff configuration

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -26,9 +26,9 @@ jobs:
         pip install ruff
     - name: fink-broker
       run: |
-        ruff check --statistics --preview fink_broker/*/*.py
-        ruff format --check --preview fink_broker/*/*.py
+        ruff check --statistics fink_broker/*/*.py
+        ruff format --check fink_broker/*/*.py
     - name: bin
       run: |
-        ruff check --preview --statistics bin/*/*.py
-        ruff format --check --preview bin/*/*.py
+        ruff check --statistics bin/*/*.py
+        ruff format --check bin/*/*.py

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -37,7 +37,7 @@ target-version = "py38"
 
 [lint]
 # Rules can be found at https://docs.astral.sh/ruff/rules
-select = ["E4", "E7", "E9", "F", "E1", "E2", "W", "N", "D", "B", "C4", "PD", "PERF"]
+select = ["E4", "E7", "E9", "F", "E1", "W", "N", "D", "B", "C4", "PD", "PERF"]
 ignore = [
     "C408", "C420", "C901",
     "D400", "D401", "D100", "D102", "D103", "D104", "D415", "D419", 

--- a/bin/elasticc/distribute_elasticc.py
+++ b/bin/elasticc/distribute_elasticc.py
@@ -74,8 +74,7 @@ def format_df_to_elasticc(df):
     # Schema is struct("classifierName", "classifierParams", "classId", "probability")
     classifications_schema = "array<struct<classifierName:string,classifierParams:string,classId:int,probability:float>>"
     df = (
-        df
-        .withColumn(
+        df.withColumn(
             "scores",
             F.array(
                 df["rf_agn_vs_nonagn"].astype("float"),
@@ -199,8 +198,7 @@ def main():
 
     # Ensure that the topic(s) exist on the Kafka Server)
     disquery = (
-        df_kafka.writeStream
-        .format("kafka")
+        df_kafka.writeStream.format("kafka")
         .option("kafka.bootstrap.servers", broker_list)
         .option("kafka.security.protocol", "SASL_PLAINTEXT")
         .option("kafka.sasl.mechanism", "SCRAM-SHA-512")

--- a/bin/rubin/archive_statistics.py
+++ b/bin/rubin/archive_statistics.py
@@ -87,8 +87,7 @@ def main():
 
     # TNS
     tns = (
-        df
-        .filter(df["xm.tns_fullname"].isNotNull())
+        df.filter(df["xm.tns_fullname"].isNotNull())
         .groupBy("xm.tns_fullname")
         .count()
         .collect()

--- a/bin/rubin/extract_schema.py
+++ b/bin/rubin/extract_schema.py
@@ -65,8 +65,7 @@ def main():
 
     # Fink versions
     fink_versions = (
-        df
-        .select(["fink_broker_version", "fink_science_version"])
+        df.select(["fink_broker_version", "fink_science_version"])
         .limit(1)
         .collect()[0]
         .asDict()

--- a/bin/rubin/fetch_schema.py
+++ b/bin/rubin/fetch_schema.py
@@ -67,8 +67,7 @@ if __name__ == "__main__":
         schema = response.text
 
         spark = (
-            SparkSession.builder
-            .master("local[1]")
+            SparkSession.builder.master("local[1]")
             .config("spark.hadoop.fs.defaultFS", "file:///")
             .getOrCreate()
         )

--- a/bin/rubin/raw2science.py
+++ b/bin/rubin/raw2science.py
@@ -105,8 +105,7 @@ def main():
 
     logger.debug("Append new rows in the tmp science data lake")
     countquery = (
-        df.writeStream
-        .outputMode("append")
+        df.writeStream.outputMode("append")
         .format("parquet")
         .option("checkpointLocation", checkpointpath_sci_tmp)
         .option("path", scitmpdatapath)

--- a/bin/rubin/stream2raw.py
+++ b/bin/rubin/stream2raw.py
@@ -338,23 +338,25 @@ if __name__ == "__main__":
     }
 
     if args.lsst_kafka_username != "ci":
-        kafka_config.update({
-            # These next two properties tell the Kafka client about the specific
-            # authentication and authorization protocols that should be used when
-            # connecting.
-            "security.protocol": "SASL_PLAINTEXT",
-            "sasl.mechanisms": "SCRAM-SHA-512",
-            # The sasl.username and sasl.password are passed through over
-            # SCRAM-SHA-512 auth to connect to the cluster. The username is not
-            # sensitive, but the password is (of course) a secret value which
-            # should never be committed to source code.
-            "sasl.username": args.lsst_kafka_username,
-            "sasl.password": args.lsst_kafka_password,
-            # Finally, we pass in the deserializer that we created above,
-            # configuring the consumer so that it automatically does all the Schema
-            # Registry and Avro deserialization work.
-            "value.deserializer": deserializer,
-        })
+        kafka_config.update(
+            {
+                # These next two properties tell the Kafka client about the specific
+                # authentication and authorization protocols that should be used when
+                # connecting.
+                "security.protocol": "SASL_PLAINTEXT",
+                "sasl.mechanisms": "SCRAM-SHA-512",
+                # The sasl.username and sasl.password are passed through over
+                # SCRAM-SHA-512 auth to connect to the cluster. The username is not
+                # sensitive, but the password is (of course) a secret value which
+                # should never be committed to source code.
+                "sasl.username": args.lsst_kafka_username,
+                "sasl.password": args.lsst_kafka_password,
+                # Finally, we pass in the deserializer that we created above,
+                # configuring the consumer so that it automatically does all the Schema
+                # Registry and Avro deserialization work.
+                "value.deserializer": deserializer,
+            }
+        )
     else:
         config.update({"avro_schema": args.avro_schema})
 
@@ -369,9 +371,9 @@ if __name__ == "__main__":
     )
 
     # check topic exists
-    kadmin = AdminClient({
-        k: v for k, v in kafka_config.items() if k != "value.deserializer"
-    })
+    kadmin = AdminClient(
+        {k: v for k, v in kafka_config.items() if k != "value.deserializer"}
+    )
     available_topics = kadmin.list_topics().topics
     while args.topic not in available_topics:
         _LOG.warning(

--- a/bin/ztf/archive_dwarf_agn.py
+++ b/bin/ztf/archive_dwarf_agn.py
@@ -57,8 +57,7 @@ def main():
 
     args_func = ["candidate.candid", "candidate.ra", "candidate.dec"]
     pdf = (
-        df
-        .withColumn("manga", crossmatch_dwarf_agn(*args_func))
+        df.withColumn("manga", crossmatch_dwarf_agn(*args_func))
         .filter(F.col("manga") != "Unknown")
         .select(["objectId", "manga"] + args_func)
         .toPandas()

--- a/bin/ztf/archive_hostless.py
+++ b/bin/ztf/archive_hostless.py
@@ -126,8 +126,7 @@ def main():
     )
 
     pdf = (
-        df
-        .filter(cond_science_low & cond_science_high)
+        df.filter(cond_science_low & cond_science_high)
         .filter(cond_template_low & cond_template_high)
         .filter(cond_max_detections)
         .select(cols_)

--- a/bin/ztf/archive_index.py
+++ b/bin/ztf/archive_index.py
@@ -186,8 +186,7 @@ def main():
 
         # explode
         df_ex = (
-            df
-            .withColumn(
+            df.withColumn(
                 "tmp", F.arrays_zip("magpsf", "sigmapsf", "diffmaglim", "jd", "fid")
             )
             .withColumn("tmp", F.explode("tmp"))
@@ -230,8 +229,7 @@ def main():
 
         # explode
         df_ex = (
-            df
-            .withColumn(
+            df.withColumn(
                 "tmp",
                 F.arrays_zip(
                     "magpsf",

--- a/bin/ztf/archive_known_tde.py
+++ b/bin/ztf/archive_known_tde.py
@@ -57,8 +57,7 @@ def main():
 
     args_func = ["candidate.isdiffpos", "candidate.ra", "candidate.dec"]
     pdf = (
-        df
-        .withColumn("tde", known_tde(*args_func))
+        df.withColumn("tde", known_tde(*args_func))
         .filter(F.col("tde") != "Unknown")
         .select(["objectId", "tde"] + args_func)
         .toPandas()

--- a/bin/ztf/archive_slsn_candidates.py
+++ b/bin/ztf/archive_slsn_candidates.py
@@ -161,9 +161,9 @@ def apply_cuts(unique):
     unique_lcs = get_and_format(list(unique["objectId"]))
 
     conversion = unique_lcs[["cmagpsf", "csigmapsf"]].apply(
-        lambda x: np.transpose([
-            mag2fluxcal_snana(*i) for i in zip(x["cmagpsf"], x["csigmapsf"])
-        ]),
+        lambda x: np.transpose(
+            [mag2fluxcal_snana(*i) for i in zip(x["cmagpsf"], x["csigmapsf"])]
+        ),
         axis=1,
     )
 
@@ -284,8 +284,7 @@ def main():
 
         # Drop images
         df_hbase = (
-            df_hbase
-            .drop("cutoutScience")
+            df_hbase.drop("cutoutScience")
             .drop("cutoutTemplate")
             .drop("cutoutDifference")
         )

--- a/bin/ztf/archive_sso_resolver.py
+++ b/bin/ztf/archive_sso_resolver.py
@@ -156,18 +156,22 @@ def main():
     sso_number_valid = sso_number[is_valid_number]
 
     # Vector contains (MPC_names, MPC_numbers, ZTF_ssnamenr)
-    index_ssodnet = np.concatenate((
-        sso_name,
-        sso_number_valid,
-        pdf.ssnamenr.to_numpy(),
-    ))
+    index_ssodnet = np.concatenate(
+        (
+            sso_name,
+            sso_number_valid,
+            pdf.ssnamenr.to_numpy(),
+        )
+    )
 
     # create index vector for Fink
-    index_fink = np.concatenate((
-        pdf.ssnamenr.to_numpy(),
-        pdf.ssnamenr[is_valid_number].to_numpy(),
-        pdf.ssnamenr.to_numpy(),
-    ))
+    index_fink = np.concatenate(
+        (
+            pdf.ssnamenr.to_numpy(),
+            pdf.ssnamenr[is_valid_number].to_numpy(),
+            pdf.ssnamenr.to_numpy(),
+        )
+    )
     index_name = np.concatenate((sso_name, sso_name[is_valid_number], sso_name))
     index_number = np.concatenate((sso_number, sso_number_valid, sso_number))
 

--- a/bin/ztf/archive_statistics.py
+++ b/bin/ztf/archive_statistics.py
@@ -96,8 +96,7 @@ def main():
 
     # matches with SIMBAD
     n_simbad = (
-        df_sci
-        .withColumn("is_simbad", simbad_candidates("cdsxmatch"))
+        df_sci.withColumn("is_simbad", simbad_candidates("cdsxmatch"))
         .filter(F.col("is_simbad"))
         .count()
     )
@@ -105,8 +104,7 @@ def main():
     out_dic["simbad_tot"] = n_simbad
 
     n_simbad_gal = (
-        df_sci
-        .select("cdsxmatch")
+        df_sci.select("cdsxmatch")
         .filter(df_sci["cdsxmatch"].isin(list(return_list_of_eg_host())))
         .count()
     )

--- a/bin/ztf/archive_symbiotic_and_cv_stars.py
+++ b/bin/ztf/archive_symbiotic_and_cv_stars.py
@@ -108,17 +108,18 @@ def main():
     # For the Symbiotic stars bot we should filter all alerts
     # with delta mag between the last 2 points bigger than 0.5 (any filter).
     pdf = (
-        df
-        .filter(df["mag_rate"] * df["delta_time"] <= -0.5)
+        df.filter(df["mag_rate"] * df["delta_time"] <= -0.5)
         .filter(~df["from_upper"])
-        .select([
-            "candidate.ra",
-            "candidate.dec",
-            "symbiotic",
-            "objectId",
-            "delta_time",
-            (df["mag_rate"] * df["delta_time"]).alias("dmag"),
-        ])
+        .select(
+            [
+                "candidate.ra",
+                "candidate.dec",
+                "symbiotic",
+                "objectId",
+                "delta_time",
+                (df["mag_rate"] * df["delta_time"]).alias("dmag"),
+            ]
+        )
         .toPandas()
     )
 

--- a/bin/ztf/push_to_tns.py
+++ b/bin/ztf/push_to_tns.py
@@ -77,8 +77,7 @@ def main():
     df = df.withColumn("class", extract_fink_classification(*cols))
 
     pdf = (
-        df
-        .filter(df["class"] == "Early SN Ia candidate")
+        df.filter(df["class"] == "Early SN Ia candidate")
         .filter(df["candidate.ndethist"] <= 20)
         .toPandas()
     )
@@ -121,9 +120,9 @@ def main():
         print(r.json())
 
         # post to slack
-        slacktxt = " \n ".join([
-            "https://ztf.fink-portal.org/{}".format(i) for i in ids
-        ])
+        slacktxt = " \n ".join(
+            ["https://ztf.fink-portal.org/{}".format(i) for i in ids]
+        )
         slacktxt = "{} \n ".format(args.night) + slacktxt
         r = requests.post(
             os.environ["TNSWEBHOOK"],

--- a/bin/ztf/raw2science.py
+++ b/bin/ztf/raw2science.py
@@ -111,8 +111,7 @@ def main():
 
     logger.debug("Append new rows in the tmp science database")
     countquery_science = (
-        df.writeStream
-        .outputMode("append")
+        df.writeStream.outputMode("append")
         .format("parquet")
         .option("checkpointLocation", checkpointpath_sci_tmp)
         .option("path", scitmpdatapath)

--- a/bin/ztf/stream2raw.py
+++ b/bin/ztf/stream2raw.py
@@ -97,16 +97,18 @@ def main():
         "kafka-cluster-kafka-bootstrap.kafka"
     ):
         # Only for test suite (sentinel or k8s)
-        df_decoded = df.select([
-            from_avro(df["value"], alert_schema_json).alias("decoded")
-        ])
+        df_decoded = df.select(
+            [from_avro(df["value"], alert_schema_json).alias("decoded")]
+        )
     elif args.producer == "elasticc":
         schema = fastavro.schema.load_schema(args.schema)
         alert_schema_json = fastavro.schema.to_parsing_canonical_form(schema)
-        df_decoded = df.select([
-            from_avro(df["value"], alert_schema_json).alias("decoded"),
-            df["topic"],
-        ])
+        df_decoded = df.select(
+            [
+                from_avro(df["value"], alert_schema_json).alias("decoded"),
+                df["topic"],
+            ]
+        )
     elif args.producer == "ztf":
         # Decode on-the-fly using fastavro
         f = F.udf(lambda x: next(fastavro.reader(io.BytesIO(x))), alert_schema)
@@ -133,8 +135,7 @@ def main():
 
         # write unpartitioned data
         countquery_tmp = (
-            df_decoded.writeStream
-            .outputMode("append")
+            df_decoded.writeStream.outputMode("append")
             .format("parquet")
             .option("checkpointLocation", checkpointpath_raw)
             .option("path", os.path.join(rawdatapath, f"{args.night}"))
@@ -151,16 +152,14 @@ def main():
         )
 
         df_partitionedby = (
-            df_decoded
-            .withColumn("timestamp", converter(df_decoded[timecol]))
+            df_decoded.withColumn("timestamp", converter(df_decoded[timecol]))
             .withColumn("year", F.date_format("timestamp", "yyyy"))
             .withColumn("month", F.date_format("timestamp", "MM"))
             .withColumn("day", F.date_format("timestamp", "dd"))
         )
 
         countquery_tmp = (
-            df_partitionedby.writeStream
-            .outputMode("append")
+            df_partitionedby.writeStream.outputMode("append")
             .format("parquet")
             .option("checkpointLocation", checkpointpath_raw)
             .option("path", rawdatapath)

--- a/fink_broker/common/distribution_utils.py
+++ b/fink_broker/common/distribution_utils.py
@@ -129,8 +129,7 @@ def push_to_kafka(
         )
 
     disquery = (
-        df_kafka.writeStream
-        .format("kafka")
+        df_kafka.writeStream.format("kafka")
         .options(**kafka_cfg)
         .option("topic", topicname)
         .option("checkpointLocation", checkpointpath_kafka + "/" + topicname)

--- a/fink_broker/common/hbase_utils.py
+++ b/fink_broker/common/hbase_utils.py
@@ -52,8 +52,7 @@ def load_hbase_data(catalog: str, rowkey: str) -> DataFrame:
     spark = SparkSession.builder.getOrCreate()
 
     df = (
-        spark.read
-        .option("catalog", catalog)
+        spark.read.option("catalog", catalog)
         .format("org.apache.hadoop.hbase.spark")
         .option("hbase.spark.use.hbasecontext", False)
         .option("hbase.spark.pushdown.columnfilter", True)
@@ -462,8 +461,7 @@ def push_to_hbase(
     if streaming:
         # FIXME: what should be the processing time?
         query = (
-            df.writeStream
-            .foreachBatch(push_to_hbase_partial(hbcatalog_index, nregion))
+            df.writeStream.foreachBatch(push_to_hbase_partial(hbcatalog_index, nregion))
             .option("checkpointLocation", checkpoint_path)
             .trigger(processingTime="60 seconds")
             .start()

--- a/fink_broker/common/partitioning.py
+++ b/fink_broker/common/partitioning.py
@@ -142,8 +142,7 @@ def compute_num_part(df, partition_size=128.0):
     logical_plan = df._jdf.queryExecution().logical()
     mode = df._jdf.queryExecution().mode()
     b = (
-        spark._jsparkSession
-        .sessionState()
+        spark._jsparkSession.sessionState()
         .executePlan(logical_plan, mode)
         .optimizedPlan()
         .stats()

--- a/fink_broker/common/spark_utils.py
+++ b/fink_broker/common/spark_utils.py
@@ -270,8 +270,7 @@ def connect_to_kafka(
 
     # Create a streaming DF from the incoming stream from Kafka
     df = (
-        spark.readStream
-        .format("kafka")
+        spark.readStream.format("kafka")
         .option("kafka.bootstrap.servers", servers)
         .option("maxOffsetsPerTrigger", max_offsets_per_trigger)
     )
@@ -300,8 +299,7 @@ def connect_to_kafka(
             )
 
     df = (
-        df
-        .option("subscribePattern", topic)
+        df.option("subscribePattern", topic)
         .option("startingOffsets", startingoffsets)
         .option("failOnDataLoss", failondataloss)
         .load()
@@ -359,8 +357,7 @@ def connect_to_raw_database(basepath: str, path: str, latestfirst: bool) -> Data
             break
 
     df = (
-        spark.readStream
-        .format("parquet")
+        spark.readStream.format("parquet")
         .schema(userschema)
         .option("basePath", basepath)
         .option("path", path)

--- a/fink_broker/common/tester.py
+++ b/fink_broker/common/tester.py
@@ -107,8 +107,7 @@ def spark_unit_tests(
 
     if withstreaming:
         dfstream = (
-            spark.readStream
-            .format("kafka")
+            spark.readStream.format("kafka")
             .option("kafka.bootstrap.servers", os.environ["KAFKA_IPPORT_SIM"])
             .option("subscribe", os.environ["KAFKA_TOPIC"])
             .option("startingOffsets", "earliest")

--- a/fink_broker/rubin/hbase_utils.py
+++ b/fink_broker/rubin/hbase_utils.py
@@ -113,11 +113,13 @@ def load_fink_cols():
     #         }
 
     # Others
-    fink_source_cols.update({
-        "fink_broker_version": {"type": "string", "default": None},
-        "fink_science_version": {"type": "string", "default": None},
-        "lsst_schema_version": {"type": "string", "default": None},
-    })
+    fink_source_cols.update(
+        {
+            "fink_broker_version": {"type": "string", "default": None},
+            "fink_science_version": {"type": "string", "default": None},
+            "lsst_schema_version": {"type": "string", "default": None},
+        }
+    )
 
     # Predictions
     fink_object_cols = {
@@ -678,8 +680,7 @@ def ingest_object_data(
             Window.unboundedPreceding, Window.unboundedFollowing
         )
         df_dedup = (
-            df
-            .withColumn("maxMjd", F.max("diaSource.midpointMjdTai").over(w))
+            df.withColumn("maxMjd", F.max("diaSource.midpointMjdTai").over(w))
             .where(F.col("diaSource.midpointMjdTai") == F.col("maxMjd"))
             .drop("maxMjd")
         )
@@ -994,8 +995,7 @@ def format_pixels_for_hbase(df, nside, streaming):
             Window.unboundedPreceding, Window.unboundedFollowing
         )
         df_dedup = (
-            df
-            .withColumn("maxMjd", F.max("diaSource.midpointMjdTai").over(w))
+            df.withColumn("maxMjd", F.max("diaSource.midpointMjdTai").over(w))
             .where(F.col("diaSource.midpointMjdTai") == F.col("maxMjd"))
             .drop("maxMjd")
         )
@@ -1115,8 +1115,7 @@ def format_fp_for_hbase(df, npartitions):
     """
     # Step 1 -- keep records with fp
     df_nonnull = (
-        df
-        .filter(F.col("diaObject.nDiaSources") > 1)
+        df.filter(F.col("diaObject.nDiaSources") > 1)
         .filter(F.col("prvDiaForcedSources").isNotNull())
         .filter(F.size("prvDiaForcedSources") > 0)
     )
@@ -1143,8 +1142,7 @@ def format_fp_for_hbase(df, npartitions):
     )
 
     df_ingest = (
-        df_filtered
-        .select("prvDiaForcedSources2")
+        df_filtered.select("prvDiaForcedSources2")
         .select(F.explode("prvDiaForcedSources2").alias("forcedSource"))
         .select("forcedSource.*")
     )

--- a/fink_broker/rubin/science.py
+++ b/fink_broker/rubin/science.py
@@ -334,9 +334,9 @@ def apply_science_modules(df: DataFrame, tns_raw_output: str = "") -> DataFrame:
         3: 21,  # Periodic: RRLyrae, EB, LPV, ...
         4: 22,  # Non-periodic: AGN
     }
-    mapping_cats_general_expr = F.create_map([
-        F.lit(x) for x in chain(*mapping_cats_general.items())
-    ])
+    mapping_cats_general_expr = F.create_map(
+        [F.lit(x) for x in chain(*mapping_cats_general.items())]
+    )
 
     df = df.withColumn(
         "cats_argmax",

--- a/fink_broker/rubin/spark_utils.py
+++ b/fink_broker/rubin/spark_utils.py
@@ -42,8 +42,7 @@ def get_schema_from_parquet(filename):
     spark = SparkSession.builder.getOrCreate()
 
     schema_version = (
-        spark.read
-        .format("parquet")
+        spark.read.format("parquet")
         .load(filename)
         .select("lsst_schema_version")
         .limit(1)

--- a/fink_broker/ztf/hbase_utils.py
+++ b/fink_broker/ztf/hbase_utils.py
@@ -462,8 +462,7 @@ def flatten_dataframe(df, root_level, section, fink_cols, fink_nested_cols):
 
             # rename root.level into root_level
             name = (
-                F
-                .col(colname)
+                F.col(colname)
                 .alias(colname.replace(".", "_"))
                 .cast(coltype_and_default["type"])
             )

--- a/fink_broker/ztf/mm_utils.py
+++ b/fink_broker/ztf/mm_utils.py
@@ -223,8 +223,7 @@ def science2mm(
     checkpointpath_mm_tmp = os.path.join(mm_path_output, "online_checkpoint")
 
     query_mm = (
-        df_multi_messenger.writeStream
-        .outputMode("append")
+        df_multi_messenger.writeStream.outputMode("append")
         .format("parquet")
         .option("checkpointLocation", checkpointpath_mm_tmp)
         .option("path", mmtmpdatapath)
@@ -259,8 +258,7 @@ def mm2distribute(spark, config: configparser.ConfigParser, args: argparse.Names
 
             path = basepath
             df_grb_stream = (
-                spark.readStream
-                .format("parquet")
+                spark.readStream.format("parquet")
                 .schema(static_df.schema)
                 .option("basePath", basepath)
                 .option("path", path)
@@ -276,8 +274,7 @@ def mm2distribute(spark, config: configparser.ConfigParser, args: argparse.Names
             continue
 
     df_grb_stream = (
-        df_grb_stream
-        .drop("brokerEndProcessTimestamp")
+        df_grb_stream.drop("brokerEndProcessTimestamp")
         .drop("brokerStartProcessTimestamp")
         .drop("brokerIngestTimestamp")
     )

--- a/fink_broker/ztf/science.py
+++ b/fink_broker/ztf/science.py
@@ -345,8 +345,7 @@ def apply_science_modules(df: DataFrame, tns_raw_output: str = "") -> DataFrame:
 
     # split features
     df = (
-        df
-        .withColumn("lc_features_g", df["lc_features"].getItem("1"))
+        df.withColumn("lc_features_g", df["lc_features"].getItem("1"))
         .withColumn("lc_features_r", df["lc_features"].getItem("2"))
         .drop("lc_features")
     )

--- a/fink_broker/ztf/tracklet_identification.py
+++ b/fink_broker/ztf/tracklet_identification.py
@@ -108,16 +108,18 @@ def add_tracklet_information(df: DataFrame) -> DataFrame:
     df_filt = apply_tracklet_cuts(df)
 
     # Initialise `tracklet` column
-    df_filt_tracklet = df_filt.withColumn("tracklet", F.lit("")).select([
-        "candid",
-        "candidate.jd",
-        "candidate.xpos",
-        "candidate.ypos",
-        "candidate.nid",
-        "tracklet",
-        "candidate.ra",
-        "candidate.dec",
-    ])
+    df_filt_tracklet = df_filt.withColumn("tracklet", F.lit("")).select(
+        [
+            "candid",
+            "candidate.jd",
+            "candidate.xpos",
+            "candidate.ypos",
+            "candidate.nid",
+            "tracklet",
+            "candidate.ra",
+            "candidate.dec",
+        ]
+    )
 
     @pandas_udf(df_filt_tracklet.schema, PandasUDFType.GROUPED_MAP)
     def extract_tracklet_number(pdf: pd.DataFrame) -> pd.DataFrame:
@@ -325,8 +327,7 @@ def add_tracklet_information(df: DataFrame) -> DataFrame:
     # extract tracklet information - beware there could be duplicated rows
     # so we use dropDuplicates to avoid these.
     df_trck = (
-        df_filt_tracklet
-        .cache()
+        df_filt_tracklet.cache()
         .dropDuplicates(["jd", "xpos", "ypos"])
         .groupBy("jd")
         .apply(extract_tracklet_number)


### PR DESCRIPTION
## Summary
- Remove `--preview` from all `ruff check`/`ruff format` calls in CI — preview rules are unstable and can cause unexpected failures between ruff versions
- Remove `E2` from `select` in `.ruff.toml` — E2xx whitespace rules partially require preview mode, and `ruff format` already handles whitespace

Closes #1205

## Test plan
- [ ] CI linter workflow passes without `--preview`
- [ ] No ruff warning about preview-only rules