### PR TITLE
Fix broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Sentinel](https://github.com/astrolabsoftware/fink-broker/actions/workflows/test.yml/badge.svg)](https://github.com/astrolabsoftware/fink-broker/actions/workflows/test.yml)
 [![PEP8](https://github.com/astrolabsoftware/fink-broker/workflows/PEP8/badge.svg)](https://github.com/astrolabsoftware/fink-broker/actions?query=workflow%3APEP8)
 [![codecov](https://codecov.io/gh/astrolabsoftware/fink-broker/branch/master/graph/badge.svg)](https://codecov.io/gh/astrolabsoftware/fink-broker)
-[![Documentation Status](https://readthedocs.org/projects/fink-broker/badge/?version=latest)](https://fink-broker.readthedocs.io/en/latest/?badge=latest)
 
 ## What is Fink?
 
@@ -35,10 +34,12 @@ All are open source, and we thank all contributors!
 ## Useful links
 
 - Website: https://fink-broker.org
-- Documentation website: https://fink-broker.readthedocs.io
+- ZTF documentation: https://doc.ztf.fink-broker.org/
+- LSST documentation: https://doc.lsst.fink-broker.org/
 - Science Portal: https://fink-portal.org
 - Publications: https://fink-broker.org/papers
-- Release notes: https://fink-broker.readthedocs.io/en/latest/release-notes
+- ZTF release notes: https://doc.ztf.fink-broker.org/release-notes/
+- LSST release notes: https://doc.lsst.fink-broker.org/release-notes/
 - Developer notes (need authentication): https://gitlab.in2p3.fr/fink
 
 ## Outside academia


### PR DESCRIPTION
**IMPORTANT: Please create an issue first before opening a Pull Request.**
Linked to issue(s): Closes https://github.com/astrolabsoftware/fink-broker/issues/1218

## What changes were proposed in this pull request?

Replace the retired Read the Docs links and badge with the current ZTF and LSST documentation and release-note URLs.

How is the issue this PR is referenced against solved with this PR?

The README now points readers to the four live URLs provided by the maintainer.

## How was this patch tested?

A focused README assertion failed before the change and passed afterward. All four replacement URLs returned HTTP 200; both reported URLs returned HTTP 404.
